### PR TITLE
Make model name matching case insensitive

### DIFF
--- a/backend/src/recommendation/capacity_planner.py
+++ b/backend/src/recommendation/capacity_planner.py
@@ -92,9 +92,9 @@ class CapacityPlanner:
             )
             return None
 
-        # Filter to only this model
+        # Filter to only this model (case-insensitive match)
         model_configs = [
-            bench for bench in matching_configs if bench.model_hf_repo == model.model_id
+            bench for bench in matching_configs if bench.model_hf_repo.lower() == model.model_id.lower()
         ]
 
         if not model_configs:

--- a/data/model_catalog.json
+++ b/data/model_catalog.json
@@ -1,130 +1,226 @@
 {
   "models": [
     {
-      "model_id": "meta-llama/Llama-3.1-8B-Instruct",
+      "model_id": "meta-llama/llama-3.1-8b-instruct",
       "name": "Llama 3.1 8B Instruct",
       "provider": "Meta",
       "family": "llama3",
       "size_parameters": "8B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "question_answering", "summarization"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "question_answering",
+        "summarization"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 3.1 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 16,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed", "translation", "summarization_short", "content_generation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed",
+        "translation",
+        "summarization_short",
+        "content_generation"
+      ],
       "approval_status": "approved",
       "notes": "Excellent general-purpose model with strong instruction following"
     },
     {
-      "model_id": "meta-llama/Llama-3.3-70B-Instruct",
+      "model_id": "meta-llama/llama-3.3-70b-instruct",
       "name": "Llama 3.3 70B Instruct",
       "provider": "Meta",
       "family": "llama3",
       "size_parameters": "70B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "question_answering", "summarization", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "question_answering",
+        "summarization",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 3.3 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 80,
-      "recommended_for": ["code_generation_detailed", "content_generation", "summarization_short", "document_analysis_rag", "long_document_summarization", "research_legal_analysis"],
+      "recommended_for": [
+        "code_generation_detailed",
+        "content_generation",
+        "summarization_short",
+        "document_analysis_rag",
+        "long_document_summarization",
+        "research_legal_analysis"
+      ],
       "approval_status": "approved",
       "notes": "High-performance model for complex reasoning tasks"
     },
     {
-      "model_id": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+      "model_id": "meta-llama/llama-4-scout-17b-16e-instruct",
       "name": "Llama 4 Scout 17B Instruct",
       "provider": "Meta",
       "family": "llama4",
       "size_parameters": "17B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 4 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 34,
-      "recommended_for": ["chatbot_conversational", "content_generation", "summarization_short", "code_generation_detailed"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "content_generation",
+        "summarization_short",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "Next-generation Llama model with improved reasoning"
     },
     {
-      "model_id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+      "model_id": "meta-llama/llama-4-maverick-17b-128e-instruct",
       "name": "Llama 4 Maverick 17B Instruct",
       "provider": "Meta",
       "family": "llama4",
       "size_parameters": "17B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 4 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 34,
-      "recommended_for": ["chatbot_conversational", "content_generation", "code_generation_detailed"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "content_generation",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "Llama 4 variant optimized for instruction following"
     },
     {
-      "model_id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+      "model_id": "meta-llama/llama-4-maverick-17b-128e-instruct-fp8",
       "name": "Llama 4 Maverick 17B Instruct FP8",
       "provider": "Meta",
       "family": "llama4",
       "size_parameters": "17B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 4 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 17,
-      "recommended_for": ["chatbot_conversational", "content_generation", "code_generation_detailed"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "content_generation",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized variant for efficient inference"
     },
     {
-      "model_id": "mistralai/Mistral-Small-24B-Instruct-2501",
+      "model_id": "mistralai/mistral-small-24b-instruct-2501",
       "name": "Mistral Small 24B Instruct",
       "provider": "Mistral AI",
       "family": "mistral",
       "size_parameters": "24B",
       "context_length": 32768,
-      "supported_tasks": ["chat", "instruction_following", "code_generation"],
-      "domain_specialization": ["general", "code"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation"
+      ],
+      "domain_specialization": [
+        "general",
+        "code"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 48,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed", "translation", "content_generation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed",
+        "translation",
+        "content_generation"
+      ],
       "approval_status": "approved",
       "notes": "Efficient model with strong code capabilities"
     },
     {
-      "model_id": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+      "model_id": "mistralai/mistral-small-3.1-24b-instruct-2503",
       "name": "Mistral Small 3.1 24B Instruct",
       "provider": "Mistral AI",
       "family": "mistral",
       "size_parameters": "24B",
       "context_length": 32768,
-      "supported_tasks": ["chat", "instruction_following", "code_generation"],
-      "domain_specialization": ["general", "code"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation"
+      ],
+      "domain_specialization": [
+        "general",
+        "code"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 48,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed", "translation", "content_generation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed",
+        "translation",
+        "content_generation"
+      ],
       "approval_status": "approved",
       "notes": "Latest Mistral Small with improved performance"
     },
     {
-      "model_id": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+      "model_id": "mistralai/mixtral-8x7b-instruct-v0.1",
       "name": "Mixtral 8x7B Instruct",
       "provider": "Mistral AI",
       "family": "mixtral",
       "size_parameters": "8x7B",
       "context_length": 32768,
-      "supported_tasks": ["chat", "instruction_following", "code_generation", "multilingual"],
-      "domain_specialization": ["general", "code", "multilingual"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation",
+        "multilingual"
+      ],
+      "domain_specialization": [
+        "general",
+        "code",
+        "multilingual"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 80,
-      "recommended_for": ["code_generation_detailed", "content_generation", "translation"],
+      "recommended_for": [
+        "code_generation_detailed",
+        "content_generation",
+        "translation"
+      ],
       "approval_status": "approved",
       "notes": "Mixture-of-experts model with excellent multilingual support"
     },
@@ -135,44 +231,83 @@
       "family": "granite",
       "size_parameters": "8B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "summarization", "rag"],
-      "domain_specialization": ["general", "enterprise"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "summarization",
+        "rag"
+      ],
+      "domain_specialization": [
+        "general",
+        "enterprise"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 16,
-      "recommended_for": ["chatbot_conversational", "document_analysis_rag", "summarization_short", "long_document_summarization"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "document_analysis_rag",
+        "summarization_short",
+        "long_document_summarization"
+      ],
       "approval_status": "approved",
       "notes": "Enterprise-focused model with strong RAG capabilities"
     },
     {
-      "model_id": "Qwen/Qwen2.5-7B-Instruct",
+      "model_id": "qwen/qwen2.5-7b-instruct",
       "name": "Qwen 2.5 7B Instruct",
       "provider": "Alibaba Cloud",
       "family": "qwen",
       "size_parameters": "7B",
       "context_length": 131072,
-      "supported_tasks": ["chat", "instruction_following", "code_generation", "multilingual"],
-      "domain_specialization": ["general", "code", "multilingual"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation",
+        "multilingual"
+      ],
+      "domain_specialization": [
+        "general",
+        "code",
+        "multilingual"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 14,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed", "translation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed",
+        "translation"
+      ],
       "approval_status": "approved",
       "notes": "Strong multilingual and code capabilities with large context window"
     },
     {
-      "model_id": "Qwen/Qwen3-8B-FP8",
+      "model_id": "qwen/qwen3-8b-fp8",
       "name": "Qwen3 8B FP8",
       "provider": "Alibaba Cloud",
       "family": "qwen",
       "size_parameters": "8B",
       "context_length": 131072,
-      "supported_tasks": ["chat", "instruction_following", "code_generation", "multilingual"],
-      "domain_specialization": ["general", "code", "multilingual"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation",
+        "multilingual"
+      ],
+      "domain_specialization": [
+        "general",
+        "code",
+        "multilingual"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 8,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed", "translation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed",
+        "translation"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized model for efficient inference with large context"
     },
@@ -183,28 +318,52 @@
       "family": "phi",
       "size_parameters": "14B",
       "context_length": 16384,
-      "supported_tasks": ["chat", "instruction_following", "reasoning", "code_generation"],
-      "domain_specialization": ["general", "code"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning",
+        "code_generation"
+      ],
+      "domain_specialization": [
+        "general",
+        "code"
+      ],
       "license": "MIT",
       "license_type": "permissive",
       "min_gpu_memory_gb": 28,
-      "recommended_for": ["code_completion", "code_generation_detailed", "chatbot_conversational"],
+      "recommended_for": [
+        "code_completion",
+        "code_generation_detailed",
+        "chatbot_conversational"
+      ],
       "approval_status": "approved",
       "notes": "Compact model with strong reasoning and code capabilities"
     },
     {
-      "model_id": "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF",
+      "model_id": "nvidia/llama-3.1-nemotron-70b-instruct-hf",
       "name": "Llama 3.1 Nemotron 70B Instruct",
       "provider": "NVIDIA",
       "family": "llama3-nemotron",
       "size_parameters": "70B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "reasoning", "summarization"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning",
+        "summarization"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "NVIDIA Open Model License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 80,
-      "recommended_for": ["document_analysis_rag", "long_document_summarization", "research_legal_analysis", "content_generation"],
+      "recommended_for": [
+        "document_analysis_rag",
+        "long_document_summarization",
+        "research_legal_analysis",
+        "content_generation"
+      ],
       "approval_status": "approved",
       "notes": "NVIDIA-optimized Llama variant with enhanced instruction following"
     },
@@ -215,12 +374,22 @@
       "family": "gpt",
       "size_parameters": "20B",
       "context_length": 8192,
-      "supported_tasks": ["chat", "instruction_following", "code_generation"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 40,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed", "content_generation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed",
+        "content_generation"
+      ],
       "approval_status": "approved",
       "notes": "Open-source GPT-style model"
     },
@@ -231,412 +400,671 @@
       "family": "gpt",
       "size_parameters": "120B",
       "context_length": 8192,
-      "supported_tasks": ["chat", "instruction_following", "code_generation", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 240,
-      "recommended_for": ["content_generation", "code_generation_detailed", "document_analysis_rag"],
+      "recommended_for": [
+        "content_generation",
+        "code_generation_detailed",
+        "document_analysis_rag"
+      ],
       "approval_status": "approved",
       "notes": "Large open-source GPT model"
     },
     {
-      "model_id": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",
+      "model_id": "redhatai/meta-llama-3.1-8b-instruct-fp8-dynamic",
       "name": "Llama 3.1 8B Instruct FP8",
       "provider": "Red Hat",
       "family": "llama3",
       "size_parameters": "8B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "question_answering"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "question_answering"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 3.1 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 8,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed", "translation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed",
+        "translation"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized Llama 3.1 for efficient inference"
     },
     {
-      "model_id": "RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic",
+      "model_id": "redhatai/llama-3.3-70b-instruct-fp8-dynamic",
       "name": "Llama 3.3 70B Instruct FP8",
       "provider": "Red Hat",
       "family": "llama3",
       "size_parameters": "70B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 3.3 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 40,
-      "recommended_for": ["document_analysis_rag", "long_document_summarization", "research_legal_analysis"],
+      "recommended_for": [
+        "document_analysis_rag",
+        "long_document_summarization",
+        "research_legal_analysis"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized Llama 3.3 for cost-effective deployment"
     },
     {
-      "model_id": "RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16",
+      "model_id": "redhatai/llama-3.3-70b-instruct-quantized.w4a16",
       "name": "Llama 3.3 70B Instruct W4A16",
       "provider": "Red Hat",
       "family": "llama3",
       "size_parameters": "70B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 3.3 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 25,
-      "recommended_for": ["document_analysis_rag", "long_document_summarization"],
+      "recommended_for": [
+        "document_analysis_rag",
+        "long_document_summarization"
+      ],
       "approval_status": "approved",
       "notes": "4-bit weight quantized for very efficient inference"
     },
     {
-      "model_id": "RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8",
+      "model_id": "redhatai/llama-3.3-70b-instruct-quantized.w8a8",
       "name": "Llama 3.3 70B Instruct W8A8",
       "provider": "Red Hat",
       "family": "llama3",
       "size_parameters": "70B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 3.3 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 35,
-      "recommended_for": ["document_analysis_rag", "long_document_summarization"],
+      "recommended_for": [
+        "document_analysis_rag",
+        "long_document_summarization"
+      ],
       "approval_status": "approved",
       "notes": "8-bit quantized for balanced quality and efficiency"
     },
     {
-      "model_id": "RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic",
+      "model_id": "redhatai/llama-4-scout-17b-16e-instruct-fp8-dynamic",
       "name": "Llama 4 Scout 17B Instruct FP8",
       "provider": "Red Hat",
       "family": "llama4",
       "size_parameters": "17B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 4 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 17,
-      "recommended_for": ["chatbot_conversational", "content_generation", "code_generation_detailed"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "content_generation",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized Llama 4 Scout"
     },
     {
-      "model_id": "RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16",
+      "model_id": "redhatai/llama-4-scout-17b-16e-instruct-quantized.w4a16",
       "name": "Llama 4 Scout 17B Instruct W4A16",
       "provider": "Red Hat",
       "family": "llama4",
       "size_parameters": "17B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Llama 4 Community License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 10,
-      "recommended_for": ["chatbot_conversational", "content_generation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "content_generation"
+      ],
       "approval_status": "approved",
       "notes": "4-bit quantized for maximum efficiency"
     },
     {
-      "model_id": "RedHatAI/Llama-3.1-Nemotron-70B-Instruct-HF-FP8-dynamic",
+      "model_id": "redhatai/llama-3.1-nemotron-70b-instruct-hf-fp8-dynamic",
       "name": "Llama 3.1 Nemotron 70B Instruct FP8",
       "provider": "Red Hat",
       "family": "llama3-nemotron",
       "size_parameters": "70B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "NVIDIA Open Model License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 40,
-      "recommended_for": ["document_analysis_rag", "long_document_summarization", "research_legal_analysis"],
+      "recommended_for": [
+        "document_analysis_rag",
+        "long_document_summarization",
+        "research_legal_analysis"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized Nemotron variant"
     },
     {
-      "model_id": "RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic",
+      "model_id": "redhatai/mistral-small-3.1-24b-instruct-2503-fp8-dynamic",
       "name": "Mistral Small 3.1 24B Instruct FP8",
       "provider": "Red Hat",
       "family": "mistral",
       "size_parameters": "24B",
       "context_length": 32768,
-      "supported_tasks": ["chat", "instruction_following", "code_generation"],
-      "domain_specialization": ["general", "code"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation"
+      ],
+      "domain_specialization": [
+        "general",
+        "code"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 24,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed", "translation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed",
+        "translation"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized Mistral Small for efficient code generation"
     },
     {
-      "model_id": "RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16",
+      "model_id": "redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w4a16",
       "name": "Mistral Small 3.1 24B Instruct W4A16",
       "provider": "Red Hat",
       "family": "mistral",
       "size_parameters": "24B",
       "context_length": 32768,
-      "supported_tasks": ["chat", "instruction_following", "code_generation"],
-      "domain_specialization": ["general", "code"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation"
+      ],
+      "domain_specialization": [
+        "general",
+        "code"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 15,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "4-bit quantized for efficient deployment"
     },
     {
-      "model_id": "RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8",
+      "model_id": "redhatai/mistral-small-3.1-24b-instruct-2503-quantized.w8a8",
       "name": "Mistral Small 3.1 24B Instruct W8A8",
       "provider": "Red Hat",
       "family": "mistral",
       "size_parameters": "24B",
       "context_length": 32768,
-      "supported_tasks": ["chat", "instruction_following", "code_generation"],
-      "domain_specialization": ["general", "code"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation"
+      ],
+      "domain_specialization": [
+        "general",
+        "code"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 20,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "8-bit quantized for balanced performance"
     },
     {
-      "model_id": "RedHatAI/granite-3.1-8b-instruct-fp8-dynamic",
+      "model_id": "redhatai/granite-3.1-8b-instruct-fp8-dynamic",
       "name": "Granite 3.1 8B Instruct FP8",
       "provider": "Red Hat",
       "family": "granite",
       "size_parameters": "8B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "summarization"],
-      "domain_specialization": ["general", "enterprise"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "summarization"
+      ],
+      "domain_specialization": [
+        "general",
+        "enterprise"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 8,
-      "recommended_for": ["chatbot_conversational", "document_analysis_rag", "summarization_short"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "document_analysis_rag",
+        "summarization_short"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized Granite for efficient enterprise deployment"
     },
     {
-      "model_id": "RedHatAI/granite-3.1-8b-instruct-quantized.w4a16",
+      "model_id": "redhatai/granite-3.1-8b-instruct-quantized.w4a16",
       "name": "Granite 3.1 8B Instruct W4A16",
       "provider": "Red Hat",
       "family": "granite",
       "size_parameters": "8B",
       "context_length": 128000,
-      "supported_tasks": ["chat", "instruction_following", "summarization"],
-      "domain_specialization": ["general", "enterprise"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "summarization"
+      ],
+      "domain_specialization": [
+        "general",
+        "enterprise"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 5,
-      "recommended_for": ["chatbot_conversational", "summarization_short"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "summarization_short"
+      ],
       "approval_status": "approved",
       "notes": "4-bit quantized Granite for maximum efficiency"
     },
     {
-      "model_id": "RedHatAI/phi-4-FP8-dynamic",
+      "model_id": "redhatai/phi-4-fp8-dynamic",
       "name": "Phi-4 FP8",
       "provider": "Red Hat",
       "family": "phi",
       "size_parameters": "14B",
       "context_length": 16384,
-      "supported_tasks": ["chat", "instruction_following", "code_generation"],
-      "domain_specialization": ["general", "code"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation"
+      ],
+      "domain_specialization": [
+        "general",
+        "code"
+      ],
       "license": "MIT",
       "license_type": "permissive",
       "min_gpu_memory_gb": 14,
-      "recommended_for": ["code_completion", "code_generation_detailed", "chatbot_conversational"],
+      "recommended_for": [
+        "code_completion",
+        "code_generation_detailed",
+        "chatbot_conversational"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized Phi-4"
     },
     {
-      "model_id": "RedHatAI/phi-4-quantized.w4a16",
+      "model_id": "redhatai/phi-4-quantized.w4a16",
       "name": "Phi-4 W4A16",
       "provider": "Red Hat",
       "family": "phi",
       "size_parameters": "14B",
       "context_length": 16384,
-      "supported_tasks": ["chat", "instruction_following", "code_generation"],
-      "domain_specialization": ["general", "code"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation"
+      ],
+      "domain_specialization": [
+        "general",
+        "code"
+      ],
       "license": "MIT",
       "license_type": "permissive",
       "min_gpu_memory_gb": 8,
-      "recommended_for": ["code_completion", "code_generation_detailed"],
+      "recommended_for": [
+        "code_completion",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "4-bit quantized Phi-4"
     },
     {
-      "model_id": "RedHatAI/phi-4-quantized.w8a8",
+      "model_id": "redhatai/phi-4-quantized.w8a8",
       "name": "Phi-4 W8A8",
       "provider": "Red Hat",
       "family": "phi",
       "size_parameters": "14B",
       "context_length": 16384,
-      "supported_tasks": ["chat", "instruction_following", "code_generation"],
-      "domain_specialization": ["general", "code"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation"
+      ],
+      "domain_specialization": [
+        "general",
+        "code"
+      ],
       "license": "MIT",
       "license_type": "permissive",
       "min_gpu_memory_gb": 10,
-      "recommended_for": ["code_completion", "code_generation_detailed"],
+      "recommended_for": [
+        "code_completion",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "8-bit quantized Phi-4"
     },
     {
-      "model_id": "RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic",
+      "model_id": "redhatai/qwen2.5-7b-instruct-fp8-dynamic",
       "name": "Qwen 2.5 7B Instruct FP8",
       "provider": "Red Hat",
       "family": "qwen",
       "size_parameters": "7B",
       "context_length": 131072,
-      "supported_tasks": ["chat", "instruction_following", "code_generation", "multilingual"],
-      "domain_specialization": ["general", "code", "multilingual"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation",
+        "multilingual"
+      ],
+      "domain_specialization": [
+        "general",
+        "code",
+        "multilingual"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 7,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed", "translation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed",
+        "translation"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized Qwen 2.5"
     },
     {
-      "model_id": "RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16",
+      "model_id": "redhatai/qwen2.5-7b-instruct-quantized.w4a16",
       "name": "Qwen 2.5 7B Instruct W4A16",
       "provider": "Red Hat",
       "family": "qwen",
       "size_parameters": "7B",
       "context_length": 131072,
-      "supported_tasks": ["chat", "instruction_following", "code_generation", "multilingual"],
-      "domain_specialization": ["general", "code", "multilingual"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation",
+        "multilingual"
+      ],
+      "domain_specialization": [
+        "general",
+        "code",
+        "multilingual"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 4,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "4-bit quantized Qwen 2.5"
     },
     {
-      "model_id": "RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8",
+      "model_id": "redhatai/qwen2.5-7b-instruct-quantized.w8a8",
       "name": "Qwen 2.5 7B Instruct W8A8",
       "provider": "Red Hat",
       "family": "qwen",
       "size_parameters": "7B",
       "context_length": 131072,
-      "supported_tasks": ["chat", "instruction_following", "code_generation", "multilingual"],
-      "domain_specialization": ["general", "code", "multilingual"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation",
+        "multilingual"
+      ],
+      "domain_specialization": [
+        "general",
+        "code",
+        "multilingual"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 5,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "8-bit quantized Qwen 2.5"
     },
     {
-      "model_id": "RedHatAI/Qwen3-8B-FP8-dynamic",
+      "model_id": "redhatai/qwen3-8b-fp8-dynamic",
       "name": "Qwen3 8B FP8 Dynamic",
       "provider": "Red Hat",
       "family": "qwen",
       "size_parameters": "8B",
       "context_length": 131072,
-      "supported_tasks": ["chat", "instruction_following", "code_generation", "multilingual"],
-      "domain_specialization": ["general", "code", "multilingual"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "code_generation",
+        "multilingual"
+      ],
+      "domain_specialization": [
+        "general",
+        "code",
+        "multilingual"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 8,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed", "translation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed",
+        "translation"
+      ],
       "approval_status": "approved",
       "notes": "FP8 dynamic quantized Qwen3"
     },
     {
-      "model_id": "RedHatAI/SmolLM3-3B-FP8-dynamic",
+      "model_id": "redhatai/smollm3-3b-fp8-dynamic",
       "name": "SmolLM3 3B FP8",
       "provider": "Red Hat",
       "family": "smollm",
       "size_parameters": "3B",
       "context_length": 8192,
-      "supported_tasks": ["chat", "instruction_following"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 3,
-      "recommended_for": ["chatbot_conversational", "code_completion"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_completion"
+      ],
       "approval_status": "approved",
       "notes": "Ultra-compact model for edge deployment"
     },
     {
-      "model_id": "RedHatAI/NVIDIA-Nemotron-Nano-9B-v2-FP8-dynamic",
+      "model_id": "redhatai/nvidia-nemotron-nano-9b-v2-fp8-dynamic",
       "name": "NVIDIA Nemotron Nano 9B FP8",
       "provider": "Red Hat",
       "family": "nemotron",
       "size_parameters": "9B",
       "context_length": 8192,
-      "supported_tasks": ["chat", "instruction_following"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "NVIDIA Open Model License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 9,
-      "recommended_for": ["chatbot_conversational", "content_generation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "content_generation"
+      ],
       "approval_status": "approved",
       "notes": "Compact NVIDIA Nemotron variant"
     },
     {
-      "model_id": "RedHatAI/gemma-3n-E4B-it-FP8-dynamic",
+      "model_id": "redhatai/gemma-3n-e4b-it-fp8-dynamic",
       "name": "Gemma 3N E4B FP8",
       "provider": "Red Hat",
       "family": "gemma",
       "size_parameters": "4B",
       "context_length": 8192,
-      "supported_tasks": ["chat", "instruction_following"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Gemma License",
       "license_type": "permissive",
       "min_gpu_memory_gb": 4,
-      "recommended_for": ["chatbot_conversational"],
+      "recommended_for": [
+        "chatbot_conversational"
+      ],
       "approval_status": "approved",
       "notes": "FP8 quantized Gemma variant"
     },
     {
-      "model_id": "RedHatAI/DeepSeek-R1-0528-quantized.w4a16",
+      "model_id": "redhatai/deepseek-r1-0528-quantized.w4a16",
       "name": "DeepSeek R1 W4A16",
       "provider": "Red Hat",
       "family": "deepseek",
       "size_parameters": "7B",
       "context_length": 16384,
-      "supported_tasks": ["chat", "instruction_following", "reasoning"],
-      "domain_specialization": ["general"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following",
+        "reasoning"
+      ],
+      "domain_specialization": [
+        "general"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 4,
-      "recommended_for": ["chatbot_conversational", "code_generation_detailed"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "4-bit quantized DeepSeek reasoning model"
     },
     {
-      "model_id": "RedHatAI/Kimi-K2-Instruct-quantized.w4a16",
+      "model_id": "redhatai/kimi-k2-instruct-quantized.w4a16",
       "name": "Kimi K2 Instruct W4A16",
       "provider": "Red Hat",
       "family": "kimi",
       "size_parameters": "7B",
       "context_length": 16384,
-      "supported_tasks": ["chat", "instruction_following"],
-      "domain_specialization": ["general", "multilingual"],
+      "supported_tasks": [
+        "chat",
+        "instruction_following"
+      ],
+      "domain_specialization": [
+        "general",
+        "multilingual"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 4,
-      "recommended_for": ["chatbot_conversational", "translation"],
+      "recommended_for": [
+        "chatbot_conversational",
+        "translation"
+      ],
       "approval_status": "approved",
       "notes": "4-bit quantized Kimi model with multilingual support"
     },
     {
-      "model_id": "RedHatAI/Qwen3-Coder-480B-A35B-Instruct-FP8",
+      "model_id": "redhatai/qwen3-coder-480b-a35b-instruct-fp8",
       "name": "Qwen3 Coder 480B FP8",
       "provider": "Red Hat",
       "family": "qwen",
       "size_parameters": "480B",
       "context_length": 32768,
-      "supported_tasks": ["code_generation", "instruction_following"],
-      "domain_specialization": ["code"],
+      "supported_tasks": [
+        "code_generation",
+        "instruction_following"
+      ],
+      "domain_specialization": [
+        "code"
+      ],
       "license": "Apache 2.0",
       "license_type": "permissive",
       "min_gpu_memory_gb": 240,
-      "recommended_for": ["code_generation_detailed"],
+      "recommended_for": [
+        "code_generation_detailed"
+      ],
       "approval_status": "approved",
       "notes": "Massive code-specialized model"
     }
@@ -646,48 +1074,64 @@
       "gpu_type": "NVIDIA-L4",
       "memory_gb": 24,
       "compute_capability": "8.9",
-      "typical_use_cases": ["inference"],
-      "cost_per_hour_usd": 0.50,
+      "typical_use_cases": [
+        "inference"
+      ],
+      "cost_per_hour_usd": 0.5,
       "availability": "high"
     },
     {
       "gpu_type": "NVIDIA-A10G",
       "memory_gb": 24,
       "compute_capability": "8.6",
-      "typical_use_cases": ["inference"],
-      "cost_per_hour_usd": 1.00,
+      "typical_use_cases": [
+        "inference"
+      ],
+      "cost_per_hour_usd": 1.0,
       "availability": "high"
     },
     {
       "gpu_type": "NVIDIA-A100-40GB",
       "memory_gb": 40,
       "compute_capability": "8.0",
-      "typical_use_cases": ["inference", "training"],
-      "cost_per_hour_usd": 3.00,
+      "typical_use_cases": [
+        "inference",
+        "training"
+      ],
+      "cost_per_hour_usd": 3.0,
       "availability": "medium"
     },
     {
       "gpu_type": "NVIDIA-A100-80GB",
       "memory_gb": 80,
       "compute_capability": "8.0",
-      "typical_use_cases": ["inference", "training"],
-      "cost_per_hour_usd": 4.50,
+      "typical_use_cases": [
+        "inference",
+        "training"
+      ],
+      "cost_per_hour_usd": 4.5,
       "availability": "medium"
     },
     {
       "gpu_type": "H100",
       "memory_gb": 80,
       "compute_capability": "9.0",
-      "typical_use_cases": ["inference", "training"],
-      "cost_per_hour_usd": 8.00,
+      "typical_use_cases": [
+        "inference",
+        "training"
+      ],
+      "cost_per_hour_usd": 8.0,
       "availability": "low"
     },
     {
       "gpu_type": "H200",
       "memory_gb": 141,
       "compute_capability": "9.0",
-      "typical_use_cases": ["inference", "training"],
-      "cost_per_hour_usd": 10.00,
+      "typical_use_cases": [
+        "inference",
+        "training"
+      ],
+      "cost_per_hour_usd": 10.0,
       "availability": "low"
     }
   ]


### PR DESCRIPTION
The real data isn't consistent in how model_hf_repo is cased. Most entries use mixed case, but some are all lowercase. The BLIS data used lowercase, while the model names in the model catalog were created directly from the real data, preserving their mixed or lowercase formats. Because the code was doing an exact, case-sensitive match, some of the BLIS results weren’t being recognized.

I updated the comparison to be case-insensitive, and everything works now.  I also converted all the model names in the model catalog to be lower case to be consistent.