### PR TITLE
Ensure ANSI SGR control codes work universally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,115 +67,115 @@ help: ## Display this help message
 ##@ Setup & Installation
 
 check-prereqs: ## Check if required tools are installed
-	@echo "$(BLUE)Checking prerequisites...$(NC)"
-	@command -v docker >/dev/null 2>&1 || (echo "$(RED)✗ docker not found$(NC). Install from https://www.docker.com/products/docker-desktop" && exit 1)
-	@echo "$(GREEN)✓ docker found$(NC)"
-	@command -v kubectl >/dev/null 2>&1 || (echo "$(RED)✗ kubectl not found$(NC). Run: brew install kubectl" && exit 1)
-	@echo "$(GREEN)✓ kubectl found$(NC)"
-	@command -v kind >/dev/null 2>&1 || (echo "$(RED)✗ kind not found$(NC). Run: brew install kind" && exit 1)
-	@echo "$(GREEN)✓ kind found$(NC)"
-	@command -v ollama >/dev/null 2>&1 || (echo "$(RED)✗ ollama not found$(NC). Run: brew install ollama" && exit 1)
-	@echo "$(GREEN)✓ ollama found$(NC)"
-	@command -v $(PYTHON) >/dev/null 2>&1 || (echo "$(RED)✗ $(PYTHON) not found$(NC). Run: brew install python@3.13" && exit 1)
-	@echo "$(GREEN)✓ $(PYTHON) found$(NC)"
+	@printf "$(BLUE)Checking prerequisites...$(NC)\n"
+	@command -v docker >/dev/null 2>&1 || (ecprintfho "$(RED)✗ docker not found$(NC). Install from https://www.docker.com/products/docker-desktop\n" && exit 1)
+	@printf "$(GREEN)✓ docker found$(NC)\n"
+	@command -v kubectl >/dev/null 2>&1 || (printf "$(RED)✗ kubectl not found$(NC). Run: brew install kubectl\n" && exit 1)
+	@printf "$(GREEN)✓ kubectl found$(NC)\n"
+	@command -v kind >/dev/null 2>&1 || (printf "$(RED)✗ kind not found$(NC). Run: brew install kind\n" && exit 1)
+	@printf "$(GREEN)✓ kind found$(NC)\n"
+	@command -v ollama >/dev/null 2>&1 || (printf "$(RED)✗ ollama not found$(NC). Run: brew install ollama\n" && exit 1)
+	@printf "$(GREEN)✓ ollama found$(NC)\n"
+	@command -v $(PYTHON) >/dev/null 2>&1 || (printf "$(RED)✗ $(PYTHON) not found$(NC). Run: brew install python@3.13\n" && exit 1)
+	@printf "$(GREEN)✓ $(PYTHON) found$(NC)\n"
 	@# Check Python version and warn if 3.14+
 	@PY_VERSION=$$($(PYTHON) -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "0.0"); \
 	if [ "$$(echo "$$PY_VERSION" | cut -d. -f1)" = "3" ] && [ "$$(echo "$$PY_VERSION" | cut -d. -f2)" -ge "14" ]; then \
-		echo "$(YELLOW)⚠ Warning: Python $$PY_VERSION detected. Some dependencies (psycopg2-binary) may not have wheels yet.$(NC)"; \
-		echo "$(YELLOW)  Recommend using Python 3.13 for best compatibility.$(NC)"; \
+		printf "$(YELLOW)⚠ Warning: Python $$PY_VERSION detected. Some dependencies (psycopg2-binary) may not have wheels yet.$(NC)\n"; \
+		printf "$(YELLOW)  Recommend using Python 3.13 for best compatibility.$(NC)\n"; \
 	fi
-	@docker info >/dev/null 2>&1 || (echo "$(RED)✗ Docker daemon not running$(NC). Start Docker Desktop" && exit 1)
-	@echo "$(GREEN)✓ Docker daemon running$(NC)"
-	@echo "$(GREEN)All prerequisites satisfied!$(NC)"
+	@docker info >/dev/null 2>&1 || (printf "$(RED)✗ Docker daemon not running$(NC). Start Docker Desktop\n" && exit 1)
+	@printf "$(GREEN)✓ Docker daemon running$(NC)\n"
+	@printf "$(GREEN)All prerequisites satisfied!$(NC)\n"
 
 setup-backend: ## Set up Python environment (includes backend and UI dependencies)
-	@echo "$(BLUE)Setting up Python environment...$(NC)"
+	@printf "$(BLUE)Setting up Python environment...$(NC)\n"
 	$(PYTHON) -m venv $(VENV)
 	. $(VENV)/bin/activate && pip install --upgrade pip
 	. $(VENV)/bin/activate && pip install -r requirements.txt
-	@echo "$(GREEN)✓ Python environment ready (includes backend and UI dependencies)$(NC)"
+	@printf "$(GREEN)✓ Python environment ready (includes backend and UI dependencies)$(NC)\n"
 
 setup-ui: setup-backend ## Set up UI (uses shared venv)
-	@echo "$(GREEN)✓ UI ready (shares project venv)$(NC)"
+	@printf "$(GREEN)✓ UI ready (shares project venv)$(NC)\n"
 
 setup-ollama: ## Pull Ollama model
-	@echo "$(BLUE)Checking if Ollama model $(OLLAMA_MODEL) is available...$(NC)"
+	@printf "$(BLUE)Checking if Ollama model $(OLLAMA_MODEL) is available...$(NC)\n"
 	@# Start ollama if not running
 	@if ! pgrep -x "ollama" > /dev/null; then \
-		echo "$(YELLOW)Starting Ollama service...$(NC)"; \
+		printf "$(YELLOW)Starting Ollama service...$(NC)\n"; \
 		ollama serve > /dev/null 2>&1 & \
 		sleep 2; \
 	fi
 	@# Check if model exists, pull if not
-	@ollama list | grep -q $(OLLAMA_MODEL) || (echo "$(YELLOW)Pulling model $(OLLAMA_MODEL)...$(NC)" && ollama pull $(OLLAMA_MODEL))
-	@echo "$(GREEN)✓ Ollama model $(OLLAMA_MODEL) ready$(NC)"
+	@ollama list | grep -q $(OLLAMA_MODEL) || (printf "$(YELLOW)Pulling model $(OLLAMA_MODEL)...$(NC)\n" && ollama pull $(OLLAMA_MODEL))
+	@printf "$(GREEN)✓ Ollama model $(OLLAMA_MODEL) ready$(NC)\n"
 
 setup: check-prereqs setup-backend setup-ui setup-ollama ## Run all setup tasks
-	@echo "$(GREEN)✓ Setup complete!$(NC)"
-	@echo ""
-	@echo "$(BLUE)Next steps:$(NC)"
-	@echo "  make cluster-start # Create Kubernetes cluster"
-	@echo "  make dev           # Start all services"
+	@printf "$(GREEN)✓ Setup complete!$(NC)\n"
+	@printf "\n"
+	@printf "$(BLUE)Next steps:$(NC)\n"
+	@printf "  make cluster-start # Create Kubernetes cluster\n"
+	@printf "  make dev           # Start all services\n"
 
 ##@ Development
 
 dev: setup-ollama ## Start all services (Ollama + Backend + UI)
-	@echo "$(BLUE)Starting all services...$(NC)"
+	@printf "$(BLUE)Starting all services...$(NC)\n"
 	@mkdir -p $(PID_DIR)
 	@$(MAKE) start-ollama
 	@sleep 3
 	@$(MAKE) start-backend
 	@sleep 3
 	@$(MAKE) start-ui
-	@echo ""
-	@echo "$(GREEN)✓ All services started!$(NC)"
-	@echo ""
-	@echo "$(BLUE)Service URLs:$(NC)"
-	@echo "  UI:      http://localhost:8501"
-	@echo "  Backend: http://localhost:8000"
-	@echo "  Ollama:  http://localhost:11434"
-	@echo ""
-	@echo "$(BLUE)Logs:$(NC)"
-	@echo "  make logs-backend"
-	@echo "  make logs-ui"
-	@echo ""
-	@echo "$(BLUE)Stop:$(NC)"
-	@echo "  make stop"
+	@printf "\n"
+	@printf "$(GREEN)✓ All services started!$(NC)\n"
+	@printf "\n"
+	@printf "$(BLUE)Service URLs:$(NC)\n"
+	@printf "  UI:      http://localhost:8501\n"
+	@printf "  Backend: http://localhost:8000\n"
+	@printf "  Ollama:  http://localhost:11434\n"
+	@printf "\n"
+	@printf "$(BLUE)Logs:$(NC)\n"
+	@printf "  make logs-backend\n"
+	@printf "  make logs-ui\n"
+	@printf "\n"
+	@printf "$(BLUE)Stop:$(NC)\n"
+	@printf "  make stop\n"
 
 start-ollama: ## Start Ollama service
-	@echo "$(BLUE)Starting Ollama...$(NC)"
+	@printf "$(BLUE)Starting Ollama...$(NC)\n"
 	@if pgrep -x "ollama" > /dev/null; then \
-		echo "$(YELLOW)Ollama already running$(NC)"; \
+		printf "$(YELLOW)Ollama already running$(NC)\n"; \
 	else \
 		ollama serve > /dev/null 2>&1 & echo $$! > $(OLLAMA_PID); \
-		echo "$(GREEN)✓ Ollama started (PID: $$(cat $(OLLAMA_PID)))$(NC)"; \
+		printf "$(GREEN)✓ Ollama started (PID: $$(cat $(OLLAMA_PID)))$(NC)\n"; \
 	fi
 
 start-backend: ## Start FastAPI backend
-	@echo "$(BLUE)Starting backend...$(NC)"
+	@printf "$(BLUE)Starting backend...$(NC)\n"
 	@mkdir -p $(PID_DIR) $(LOG_DIR)
 	@if [ -f $(BACKEND_PID) ] && [ -s $(BACKEND_PID) ] && kill -0 $$(cat $(BACKEND_PID) 2>/dev/null) 2>/dev/null; then \
-		echo "$(YELLOW)Backend already running (PID: $$(cat $(BACKEND_PID)))$(NC)"; \
+		printf "$(YELLOW)Backend already running (PID: $$(cat $(BACKEND_PID)))$(NC)\n"; \
 	else \
 		. $(VENV)/bin/activate && cd $(BACKEND_DIR) && \
 		( uvicorn src.api.routes:app --reload --host 0.0.0.0 --port 8000 > ../$(LOG_DIR)/backend.log 2>&1 & echo $$! > ../$(BACKEND_PID) ); \
 		sleep 2; \
-		echo "$(GREEN)✓ Backend started (PID: $$(cat $(BACKEND_PID)))$(NC)"; \
+		printf "$(GREEN)✓ Backend started (PID: $$(cat $(BACKEND_PID)))$(NC)\n"; \
 	fi
 
 start-ui: ## Start Streamlit UI
-	@echo "$(BLUE)Starting UI...$(NC)"
+	@printf "$(BLUE)Starting UI...$(NC)\n"
 	@mkdir -p $(PID_DIR) $(LOG_DIR)
 	@if [ -f $(UI_PID) ] && [ -s $(UI_PID) ] && kill -0 $$(cat $(UI_PID) 2>/dev/null) 2>/dev/null; then \
-		echo "$(YELLOW)UI already running (PID: $$(cat $(UI_PID)))$(NC)"; \
+		printf "$(YELLOW)UI already running (PID: $$(cat $(UI_PID)))$(NC)\n"; \
 	else \
 		. $(VENV)/bin/activate && streamlit run $(UI_DIR)/app.py --server.headless true > $(LOG_DIR)/ui.log 2>&1 & echo $$! > $(UI_PID); \
 		sleep 2; \
-		echo "$(GREEN)✓ UI started (PID: $$(cat $(UI_PID)))$(NC)"; \
+		printf "$(GREEN)✓ UI started (PID: $$(cat $(UI_PID)))$(NC)\n"; \
 	fi
 
 stop: ## Stop all services
-	@echo "$(BLUE)Stopping services...$(NC)"
+	@printf "$(BLUE)Stopping services...$(NC)\n"
 	@# Stop by PID files first
 	@if [ -f $(UI_PID) ]; then \
 		kill $$(cat $(UI_PID)) 2>/dev/null || true; \
@@ -193,9 +193,9 @@ stop: ## Stop all services
 	@# Force kill if still running
 	@pkill -9 -f "streamlit run ui/app.py" 2>/dev/null || true
 	@pkill -9 -f "uvicorn src.api.routes:app" 2>/dev/null || true
-	@echo "$(GREEN)✓ All Compass services stopped$(NC)"
+	@printf "$(GREEN)✓ All Compass services stopped$(NC)\n"
 	@# Don't stop Ollama as it might be used by other apps
-	@echo "$(YELLOW)Note: Ollama left running (use 'pkill ollama' to stop manually)$(NC)"
+	@printf "$(YELLOW)Note: Ollama left running (use 'pkill ollama' to stop manually)$(NC)\n"
 
 restart: stop dev ## Restart all services
 
@@ -212,10 +212,10 @@ logs-ui-f: ## Follow UI logs (tail -f)
 	@tail -f $(LOG_DIR)/ui.log
 
 health: ## Check if all services are running
-	@echo "$(BLUE)Checking service health...$(NC)"
-	@curl -s http://localhost:8000/health > /dev/null && echo "$(GREEN)✓ Backend healthy$(NC)" || echo "$(RED)✗ Backend not responding$(NC)"
-	@curl -s http://localhost:8501 > /dev/null && echo "$(GREEN)✓ UI healthy$(NC)" || echo "$(RED)✗ UI not responding$(NC)"
-	@curl -s http://localhost:11434/api/tags > /dev/null && echo "$(GREEN)✓ Ollama healthy$(NC)" || echo "$(RED)✗ Ollama not responding$(NC)"
+	@printf "$(BLUE)Checking service health...$(NC)\n"
+	@curl -s http://localhost:8000/health > /dev/null && printf "$(GREEN)✓ Backend healthy$(NC)\n" || printf "$(RED)✗ Backend not responding$(NC)\n"
+	@curl -s http://localhost:8501 > /dev/null && printf "$(GREEN)✓ UI healthy$(NC)\n" || printf "$(RED)✗ UI not responding$(NC)\n"
+	@curl -s http://localhost:11434/api/tags > /dev/null && printf "$(GREEN)✓ Ollama healthy$(NC)\n" || printf "$(RED)✗ Ollama not responding$(NC)\n"
 
 open-ui: ## Open UI in browser
 	@$(OPEN_CMD) http://localhost:8501
@@ -226,71 +226,71 @@ open-backend: ## Open backend API docs in browser
 ##@ Docker & Simulator
 
 build-simulator: ## Build vLLM simulator Docker image
-	@echo "$(BLUE)Building simulator image...$(NC)"
+	@printf "$(BLUE)Building simulator image...$(NC)\n"
 	cd $(SIMULATOR_DIR) && docker build -t vllm-simulator:latest -t $(SIMULATOR_FULL_IMAGE) .
-	@echo "$(GREEN)✓ Simulator image built:$(NC)"
-	@echo "  - vllm-simulator:latest"
-	@echo "  - $(SIMULATOR_FULL_IMAGE)"
+	@printf "$(GREEN)✓ Simulator image built:$(NC)\n"
+	@printf "  - vllm-simulator:latest\n"
+	@printf "  - $(SIMULATOR_FULL_IMAGE)\n"
 
 push-simulator: build-simulator ## Push simulator image to Quay.io
-	@echo "$(BLUE)Pushing simulator image to $(SIMULATOR_FULL_IMAGE)...$(NC)"
+	@printf "$(BLUE)Pushing simulator image to $(SIMULATOR_FULL_IMAGE)...$(NC)\n"
 	@# Check if logged in to Quay.io
 	@if ! docker login quay.io --get-login > /dev/null 2>&1; then \
-		echo "$(YELLOW)Not logged in to Quay.io. Please login:$(NC)"; \
-		docker login quay.io || (echo "$(RED)✗ Login failed$(NC)" && exit 1); \
+		printf "$(YELLOW)Not logged in to Quay.io. Please login:$(NC)\n"; \
+		docker login quay.io || (printf "$(RED)✗ Login failed$(NC)\n" && exit 1); \
 	else \
-		echo "$(GREEN)✓ Already logged in to Quay.io$(NC)"; \
+		printf "$(GREEN)✓ Already logged in to Quay.io$(NC)\n"; \
 	fi
-	@echo "$(BLUE)Pushing image...$(NC)"
+	@printf "$(BLUE)Pushing image...$(NC)\n"
 	docker push $(SIMULATOR_FULL_IMAGE)
-	@echo "$(GREEN)✓ Image pushed to $(SIMULATOR_FULL_IMAGE)$(NC)"
+	@printf "$(GREEN)✓ Image pushed to $(SIMULATOR_FULL_IMAGE)$(NC)\n"
 
 pull-simulator: ## Pull simulator image from Quay.io
-	@echo "$(BLUE)Pulling simulator image from $(SIMULATOR_FULL_IMAGE)...$(NC)"
+	@printf "$(BLUE)Pulling simulator image from $(SIMULATOR_FULL_IMAGE)...$(NC)\n"
 	docker pull $(SIMULATOR_FULL_IMAGE)
 	docker tag $(SIMULATOR_FULL_IMAGE) vllm-simulator:latest
-	@echo "$(GREEN)✓ Image pulled and tagged as vllm-simulator:latest$(NC)"
+	@printf "$(GREEN)✓ Image pulled and tagged as vllm-simulator:latest$(NC)\n"
 
 ##@ Kubernetes Cluster
 
 cluster-start: check-prereqs build-simulator ## Create KIND cluster and load simulator image
-	@echo "$(BLUE)Creating KIND cluster...$(NC)"
+	@printf "$(BLUE)Creating KIND cluster...$(NC)\n"
 	./scripts/kind-cluster.sh start
-	@echo "$(GREEN)✓ Cluster ready!$(NC)"
+	@printf "$(GREEN)✓ Cluster ready!$(NC)\n"
 
 cluster-stop: ## Delete KIND cluster
-	@echo "$(BLUE)Stopping KIND cluster...$(NC)"
+	@printf "$(BLUE)Stopping KIND cluster...$(NC)\n"
 	./scripts/kind-cluster.sh stop
-	@echo "$(GREEN)✓ Cluster deleted$(NC)"
+	@printf "$(GREEN)✓ Cluster deleted$(NC)\n"
 
 cluster-restart: ## Restart KIND cluster
-	@echo "$(BLUE)Restarting KIND cluster...$(NC)"
+	@printf "$(BLUE)Restarting KIND cluster...$(NC)\n"
 	./scripts/kind-cluster.sh restart
-	@echo "$(GREEN)✓ Cluster restarted$(NC)"
+	@printf "$(GREEN)✓ Cluster restarted$(NC)\n"
 
 cluster-status: ## Show cluster status
 	./scripts/kind-cluster.sh status
 
 cluster-load-simulator: build-simulator ## Load simulator image into KIND cluster
-	@echo "$(BLUE)Loading simulator image into KIND cluster...$(NC)"
+	@printf "$(BLUE)Loading simulator image into KIND cluster...$(NC)\n"
 	kind load docker-image vllm-simulator:latest --name $(KIND_CLUSTER_NAME)
-	@echo "$(GREEN)✓ Simulator image loaded$(NC)"
+	@printf "$(GREEN)✓ Simulator image loaded$(NC)\n"
 
 clean-deployments: ## Delete all InferenceServices from cluster
-	@echo "$(BLUE)Deleting all InferenceServices...$(NC)"
+	@printf "$(BLUE)Deleting all InferenceServices...$(NC)\n"
 	kubectl delete inferenceservices --all
-	@echo "$(GREEN)✓ All deployments deleted$(NC)"
+	@printf "$(GREEN)✓ All deployments deleted$(NC)\n"
 
 ##@ PostgreSQL Database
 
 postgres-start: ## Start PostgreSQL container for benchmark data
-	@echo "$(BLUE)Starting PostgreSQL...$(NC)"
+	@printf "$(BLUE)Starting PostgreSQL...$(NC)\n"
 	@if docker ps -a --format '{{.Names}}' | grep -q '^compass-postgres$$'; then \
 		if docker ps --format '{{.Names}}' | grep -q '^compass-postgres$$'; then \
-			echo "$(YELLOW)PostgreSQL already running$(NC)"; \
+			printf "$(YELLOW)PostgreSQL already running$(NC)\n"; \
 		else \
 			docker start compass-postgres; \
-			echo "$(GREEN)✓ PostgreSQL started$(NC)"; \
+			printf "$(GREEN)✓ PostgreSQL started$(NC)\n"; \
 		fi \
 	else \
 		docker run --name compass-postgres -d \
@@ -299,41 +299,41 @@ postgres-start: ## Start PostgreSQL container for benchmark data
 			-p 5432:5432 \
 			postgres:16; \
 		sleep 3; \
-		echo "$(GREEN)✓ PostgreSQL started on port 5432$(NC)"; \
+		printf "$(GREEN)✓ PostgreSQL started on port 5432$(NC)\n"; \
 	fi
-	@echo "$(BLUE)Database URL:$(NC) postgresql://postgres:compass@localhost:5432/compass"
+	@printf "$(BLUE)Database URL:$(NC) postgresql://postgres:compass@localhost:5432/compass\n"
 
 postgres-stop: ## Stop PostgreSQL container
-	@echo "$(BLUE)Stopping PostgreSQL...$(NC)"
+	@printf "$(BLUE)Stopping PostgreSQL...$(NC)\n"
 	@docker stop compass-postgres 2>/dev/null || true
-	@echo "$(GREEN)✓ PostgreSQL stopped$(NC)"
+	@printf "$(GREEN)✓ PostgreSQL stopped$(NC)\n"
 
 postgres-remove: postgres-stop ## Stop and remove PostgreSQL container
-	@echo "$(BLUE)Removing PostgreSQL container...$(NC)"
+	@printf "$(BLUE)Removing PostgreSQL container...$(NC)\n"
 	@docker rm compass-postgres 2>/dev/null || true
-	@echo "$(GREEN)✓ PostgreSQL container removed$(NC)"
+	@printf "$(GREEN)✓ PostgreSQL container removed$(NC)\n"
 
 postgres-init: postgres-start ## Initialize PostgreSQL schema
-	@echo "$(BLUE)Initializing PostgreSQL schema...$(NC)"
+	@printf "$(BLUE)Initializing PostgreSQL schema...$(NC)\n"
 	@sleep 2
 	@docker exec -i compass-postgres psql -U postgres -d compass < scripts/schema.sql
-	@echo "$(GREEN)✓ Schema initialized$(NC)"
+	@printf "$(GREEN)✓ Schema initialized$(NC)\n"
 
 postgres-load-synthetic: postgres-init ## Load synthetic benchmark data from JSON
-	@echo "$(BLUE)Loading synthetic benchmark data...$(NC)"
+	@printf "$(BLUE)Loading synthetic benchmark data...$(NC)\n"
 	@. $(VENV)/bin/activate && $(PYTHON) scripts/load_benchmarks.py data/benchmarks_synthetic.json
-	@echo "$(GREEN)✓ Synthetic data loaded$(NC)"
+	@printf "$(GREEN)✓ Synthetic data loaded$(NC)\n"
 
 postgres-load-blis: postgres-init ## Load BLIS benchmark data from JSON
-	@echo "$(BLUE)Loading BLIS benchmark data...$(NC)"
+	@printf "$(BLUE)Loading BLIS benchmark data...$(NC)\n"
 	@. $(VENV)/bin/activate && $(PYTHON) scripts/load_benchmarks.py data/benchmarks_BLIS.json
-	@echo "$(GREEN)✓ BLIS data loaded$(NC)"
+	@printf "$(GREEN)✓ BLIS data loaded$(NC)\n"
 
 postgres-load-real: postgres-init ## Load real benchmark data from SQL dump
-	@echo "$(BLUE)Loading real benchmark data from integ-oct-29.sql...$(NC)"
+	@printf "$(BLUE)Loading real benchmark data from integ-oct-29.sql...$(NC)\n"
 	@if [ ! -f data/integ-oct-29.sql ]; then \
-		echo "$(RED)✗ data/integ-oct-29.sql not found$(NC)"; \
-		echo "$(YELLOW)This file is not in version control due to NDA restrictions$(NC)"; \
+		printf "$(RED)✗ data/integ-oct-29.sql not found$(NC)\n"; \
+		printf "$(YELLOW)This file is not in version control due to NDA restrictions$(NC)\n"; \
 		exit 1; \
 	fi
 	@# Copy dump file into container temporarily
@@ -343,8 +343,8 @@ postgres-load-real: postgres-init ## Load real benchmark data from SQL dump
 	@# Clean up
 	@docker exec compass-postgres rm /tmp/integ-oct-29.sql
 	@# Show statistics
-	@echo ""
-	@echo "$(BLUE)📊 Database Statistics:$(NC)"
+	@printf "\n"
+	@printf "$(BLUE)📊 Database Statistics:$(NC)\n"
 	@docker exec -i compass-postgres psql -U postgres -d compass -c \
 		"SELECT COUNT(*) as total_benchmarks FROM exported_summaries;" | grep -v "^-" | grep -v "row"
 	@docker exec -i compass-postgres psql -U postgres -d compass -c \
@@ -353,13 +353,13 @@ postgres-load-real: postgres-init ## Load real benchmark data from SQL dump
 		"SELECT COUNT(DISTINCT hardware) as num_hardware_types FROM exported_summaries;" | grep -v "^-" | grep -v "row"
 	@docker exec -i compass-postgres psql -U postgres -d compass -c \
 		"SELECT COUNT(DISTINCT (prompt_tokens, output_tokens)) as num_traffic_profiles FROM exported_summaries WHERE prompt_tokens IS NOT NULL;" | grep -v "^-" | grep -v "row"
-	@echo "$(GREEN)✓ Real benchmark data loaded$(NC)"
+	@printf "$(GREEN)✓ Real benchmark data loaded$(NC)\n"
 
 postgres-shell: ## Open PostgreSQL shell
 	@docker exec -it compass-postgres psql -U postgres -d compass
 
 postgres-query-traffic: ## Query unique traffic patterns from database
-	@echo "$(BLUE)Querying unique traffic patterns...$(NC)"
+	@printf "$(BLUE)Querying unique traffic patterns...$(NC)\n"
 	@docker exec -i compass-postgres psql -U postgres -d compass -c \
 		"SELECT DISTINCT mean_input_tokens, mean_output_tokens, COUNT(*) as num_benchmarks \
 		FROM exported_summaries \
@@ -367,7 +367,7 @@ postgres-query-traffic: ## Query unique traffic patterns from database
 		ORDER BY mean_input_tokens, mean_output_tokens;"
 
 postgres-query-models: ## Query available models in database
-	@echo "$(BLUE)Querying available models...$(NC)"
+	@printf "$(BLUE)Querying available models...$(NC)\n"
 	@docker exec -i compass-postgres psql -U postgres -d compass -c \
 		"SELECT DISTINCT model_hf_repo, hardware, hardware_count, COUNT(*) as num_benchmarks \
 		FROM exported_summaries \
@@ -375,56 +375,56 @@ postgres-query-models: ## Query available models in database
 		ORDER BY model_hf_repo, hardware, hardware_count;"
 
 postgres-reset: postgres-remove postgres-init ## Reset PostgreSQL (remove and reinitialize)
-	@echo "$(GREEN)✓ PostgreSQL reset complete$(NC)"
+	@printf "$(GREEN)✓ PostgreSQL reset complete$(NC)\n"
 
 ##@ Testing
 
 test: test-unit ## Run all tests
-	@echo "$(GREEN)✓ All tests passed$(NC)"
+	@printf "$(GREEN)✓ All tests passed$(NC)\n"
 
 test-unit: ## Run unit tests
-	@echo "$(BLUE)Running unit tests...$(NC)"
+	@printf "$(BLUE)Running unit tests...$(NC)\n"
 	. $(VENV)/bin/activate && cd $(BACKEND_DIR) && pytest ../tests/ -v -m "not integration and not e2e"
 
 test-integration: setup-ollama ## Run integration tests (requires Ollama)
-	@echo "$(BLUE)Running integration tests...$(NC)"
+	@printf "$(BLUE)Running integration tests...$(NC)\n"
 	. $(VENV)/bin/activate && cd $(BACKEND_DIR) && pytest ../tests/ -v -m integration
 
 test-e2e: ## Run end-to-end tests (requires cluster)
-	@echo "$(BLUE)Running end-to-end tests...$(NC)"
-	@kubectl cluster-info > /dev/null 2>&1 || (echo "$(RED)✗ Kubernetes cluster not accessible$(NC). Run: make cluster-start" && exit 1)
+	@printf "$(BLUE)Running end-to-end tests...$(NC)\n"
+	@kubectl cluster-info > /dev/null 2>&1 || (printf "$(RED)✗ Kubernetes cluster not accessible$(NC). Run: make cluster-start\n" && exit 1)
 	. $(VENV)/bin/activate && cd $(BACKEND_DIR) && pytest ../tests/ -v -m e2e
 
 test-workflow: setup-ollama ## Run workflow integration test
-	@echo "$(BLUE)Running workflow test...$(NC)"
+	@printf "$(BLUE)Running workflow test...$(NC)\n"
 	. $(VENV)/bin/activate && cd $(BACKEND_DIR) && $(PYTHON) test_workflow.py
 
 test-watch: ## Run tests in watch mode
-	@echo "$(BLUE)Running tests in watch mode...$(NC)"
+	@printf "$(BLUE)Running tests in watch mode...$(NC)\n"
 	. $(VENV)/bin/activate && cd $(BACKEND_DIR) && pytest-watch
 
 ##@ Code Quality
 
 lint: ## Run linters
-	@echo "$(BLUE)Running linters...$(NC)"
+	@printf "$(BLUE)Running linters...$(NC)\n"
 	@if [ -d $(VENV) ]; then \
 		. $(VENV)/bin/activate && \
-		(command -v ruff >/dev/null 2>&1 && ruff check $(BACKEND_DIR)/src/ $(UI_DIR)/*.py || echo "$(YELLOW)ruff not installed, skipping$(NC)"); \
+		(command -v ruff >/dev/null 2>&1 && ruff check $(BACKEND_DIR)/src/ $(UI_DIR)/*.py || printf "$(YELLOW)ruff not installed, skipping$(NC)\n"); \
 	fi
-	@echo "$(GREEN)✓ Linting complete$(NC)"
+	@printf "$(GREEN)✓ Linting complete$(NC)\n"
 
 format: ## Auto-format code
-	@echo "$(BLUE)Formatting code...$(NC)"
+	@printf "$(BLUE)Formatting code...$(NC)\n"
 	@if [ -d $(VENV) ]; then \
 		. $(VENV)/bin/activate && \
-		(command -v ruff >/dev/null 2>&1 && ruff format $(BACKEND_DIR)/ $(UI_DIR)/ || echo "$(YELLOW)ruff not installed, skipping$(NC)"); \
+		(command -v ruff >/dev/null 2>&1 && ruff format $(BACKEND_DIR)/ $(UI_DIR)/ || printf "$(YELLOW)ruff not installed, skipping$(NC)\n"); \
 	fi
-	@echo "$(GREEN)✓ Formatting complete$(NC)"
+	@printf "$(GREEN)✓ Formatting complete$(NC)\n"
 
 ##@ Cleanup
 
 clean: ## Clean generated files and caches
-	@echo "$(BLUE)Cleaning generated files...$(NC)"
+	@printf "$(BLUE)Cleaning generated files...$(NC)\n"
 	rm -rf $(PID_DIR)
 	rm -f $(BACKEND_PID).log $(UI_PID).log
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
@@ -432,30 +432,30 @@ clean: ## Clean generated files and caches
 	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
 	rm -rf generated_configs/*.yaml 2>/dev/null || true
 	rm -rf logs/prompts/*.txt 2>/dev/null || true
-	@echo "$(GREEN)✓ Cleanup complete$(NC)"
+	@printf "$(GREEN)✓ Cleanup complete$(NC)\n"
 
 clean-all: clean ## Clean everything including virtual environments
-	@echo "$(BLUE)Cleaning virtual environments...$(NC)"
+	@printf "$(BLUE)Cleaning virtual environments...$(NC)\n"
 	rm -rf $(VENV)
-	@echo "$(GREEN)✓ Deep cleanup complete$(NC)"
+	@printf "$(GREEN)✓ Deep cleanup complete$(NC)\n"
 
 ##@ Utilities
 
 info: ## Show configuration and platform info
-	@echo "$(BLUE)Platform Information:$(NC)"
-	@echo "  Platform: $(PLATFORM)"
-	@echo "  OS: $(UNAME_S)"
-	@echo "  Arch: $(UNAME_M)"
-	@echo "  Python: $(PYTHON) ($$($(PYTHON) --version 2>&1))"
-	@echo ""
-	@echo "$(BLUE)Configuration:$(NC)"
-	@echo "  Registry: $(REGISTRY)"
-	@echo "  Org: $(REGISTRY_ORG)"
-	@echo "  Simulator Image: $(SIMULATOR_FULL_IMAGE)"
-	@echo "  Ollama Model: $(OLLAMA_MODEL)"
-	@echo "  KIND Cluster: $(KIND_CLUSTER_NAME)"
-	@echo ""
-	@echo "$(BLUE)Paths:$(NC)"
-	@echo "  Backend: $(BACKEND_DIR)"
-	@echo "  UI: $(UI_DIR)"
-	@echo "  Simulator: $(SIMULATOR_DIR)"
+	@printf "$(BLUE)Platform Information:$(NC)\n"
+	@printf "  Platform: $(PLATFORM)\n"
+	@printf "  OS: $(UNAME_S)\n"
+	@printf "  Arch: $(UNAME_M)\n"
+	@printf "  Python: $(PYTHON) ($$($(PYTHON) --version 2>&1))\n"
+	@printf "\n"
+	@printf "$(BLUE)Configuration:$(NC)\n"
+	@printf "  Registry: $(REGISTRY)\n"
+	@printf "  Org: $(REGISTRY_ORG)\n"
+	@printf "  Simulator Image: $(SIMULATOR_FULL_IMAGE)\n"
+	@printf "  Ollama Model: $(OLLAMA_MODEL)\n"
+	@printf "  KIND Cluster: $(KIND_CLUSTER_NAME)\n"
+	@printf "\n"
+	@printf "$(BLUE)Paths:$(NC)\n"
+	@printf "  Backend: $(BACKEND_DIR)\n"
+	@printf "  UI: $(UI_DIR)\n"
+	@printf "  Simulator: $(SIMULATOR_DIR)\n"


### PR DESCRIPTION
`echo` does not interpret escape sequences on all shells and systems. Adding the `-e` flag may allow this to work on some systems, but apparently is not guaranteed to be portable. Changing to `printf` and adding a line feed to the end should create the desired behavior in a universal way.