### PR TITLE
fix: Improve LLM prompt for better use case classification

### DIFF
--- a/backend/src/llm/prompts.py
+++ b/backend/src/llm/prompts.py
@@ -75,6 +75,10 @@ Be intelligent about inference:
 - "budget is flexible" or "no budget constraint" → budget_constraint: flexible or none
 - No budget mentioned → budget_constraint: moderate
 - "cost-sensitive" or "cost efficiency important" → budget_constraint: strict or moderate
+- "document Q&A" or "knowledge base" or "document search" → use_case: document_analysis_rag
+- "RAG" or "retrieval" → use_case: document_analysis_rag
+- "chatbot" or "customer service" or "conversational" → use_case: chatbot_conversational
+- "summarize document" or "summarization" → use_case: summarization_short or long_document_summarization
 
 {INTENT_EXTRACTION_SCHEMA}
 """


### PR DESCRIPTION
Add explicit inference hints for document Q&A, RAG, chatbot, and summarization use cases to help Qwen 2.5 correctly classify user inputs.

Before: 'Document Q&A system' was misclassified as chatbot_conversational
After: 'Document Q&A system' correctly maps to document_analysis_rag

Tested with multiple inputs to verify correct classification.

Signed-off-by: Yuval Luria <yluria@redhat.com>