### PR TITLE
refactor: Implement capped latency scoring using SLO ranges

### DIFF
--- a/backend/src/recommendation/capacity_planner.py
+++ b/backend/src/recommendation/capacity_planner.py
@@ -227,8 +227,6 @@ class CapacityPlanner:
             predicted_ttft = int(bench.ttft_p95) if bench.ttft_p95 else 0
             predicted_itl = int(bench.itl_p95) if bench.itl_p95 else 0
             predicted_e2e = int(bench.e2e_p95) if bench.e2e_p95 else 0
-            # Use tps_mean for throughput, fallback to tokens_per_second
-            throughput_tps = float(bench.tps_mean) if bench.tps_mean else (float(bench.tokens_per_second) if bench.tokens_per_second else 0)
 
             latency_score, slo_status = scorer.score_latency(
                 predicted_ttft_ms=predicted_ttft,
@@ -237,8 +235,8 @@ class CapacityPlanner:
                 target_ttft_ms=slo_targets.ttft_p95_target_ms,
                 target_itl_ms=slo_targets.itl_p95_target_ms,
                 target_e2e_ms=slo_targets.e2e_p95_target_ms,
-                throughput_tps=throughput_tps,
-                use_case=intent.use_case,  # Dynamic benchmarks per use case
+                use_case=intent.use_case,
+                near_miss_tolerance=near_miss_tolerance,
             )
 
             # Skip if exceeds SLO and we're not including near-miss


### PR DESCRIPTION
Replace absolute performance + headroom scoring with capped range scoring that uses min/max thresholds from usecase_slo_workload.json:

- At or below "min": score 100 (no extra credit for exceeding requirements)
- Between min and max: linear interpolation 100→60
- Above max: penalty zone with scores below 60

This removes the bias toward low-latency configurations that exceed user requirements. Configurations that meet the "excellent" threshold are now scored equally, regardless of how far below that threshold they perform.

Changes:
- Add __init__ and _load_slo_ranges() to load SLO ranges from JSON
- Add _calculate_capped_latency_score() helper for capped scoring
- Rewrite score_latency() to use capped scoring approach
- Remove ~70 lines of hardcoded LATENCY_BENCHMARKS_BY_USE_CASE constants
- Remove unused throughput_tps parameter
- Use near_miss_tolerance from capacity_planner instead of hardcoding 1.2