### PR TITLE
fix(ui): Fix session state error for task preset buttons

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -4585,14 +4585,14 @@ def render_use_case_input_tab(priority: str, models_df: pd.DataFrame):
         if st.button("Long Doc Summary", use_container_width=True, key="task_longdoc"):
             clear_dialog_states()
             # With priority (accuracy) to show filtering
-            st.session_state.user_input = "Long document summarization for research papers, 30 researchers, accuracy matters."
+            st.session_state.pending_user_input = "Long document summarization for research papers, 30 researchers, accuracy matters."
             st.rerun()
 
     with col9:
         if st.button("Code Generation", use_container_width=True, key="task_codegen"):
             clear_dialog_states()
             # Simple prompt - no priority, no hardware = show all configs
-            st.session_state.user_input = "Full code generation tool for implementing features, 30 developers."
+            st.session_state.pending_user_input = "Full code generation tool for implementing features, 30 developers."
             st.rerun()
     
     # Show character count - white text


### PR DESCRIPTION
Two task buttons ("Long Doc Summary" and "Code Generation") were attempting to modify st.session_state.user_input after the text_area widget had already been instantiated, causing StreamlitAPIException.

Changed both buttons to use the existing pending_user_input pattern that all other task buttons use. This defers the session state modification to the next render cycle, avoiding the conflict with the text_area widget's key binding.

Error fixed:
StreamlitAPIException: st.session_state.user_input cannot be modified after the widget with key user_input is instantiated.