### PR TITLE
feat: Restore the UI for Deploying to Kubernetes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ check-prereqs: ## Check if required tools are installed
 
 setup-backend: ## Set up Python environment (includes backend and UI dependencies)
 	@printf "$(BLUE)Setting up Python environment...$(NC)\n"
-	uv sync
+	uv sync --extra ui --extra dev
 	@printf "$(GREEN)✓ Python environment ready (includes backend and UI dependencies)$(NC)\n"
 
 setup-ui: setup-backend ## Set up UI (uses shared venv)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for detailed system design.
 | LLM | Ollama (qwen2.5:7b) |
 | Data | PostgreSQL |
 | YAML Generation | Jinja2 templates |
-| Kubernetes | KIND (local), KServe v0.13.0 |
+| Kubernetes | KIND (local), KServe v0.14.0 |
 | Deployment | kubectl |
 
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -885,8 +885,8 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 kubectl wait --for=condition=available --timeout=300s -n cert-manager deployment/cert-manager
 
 # Install KServe
-kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.13.0/kserve.yaml
-kubectl apply -f https://github.com/kserve/kserve/releases/download/v0.13.0/kserve-cluster-resources.yaml
+kubectl apply --server-side -f https://github.com/kserve/kserve/releases/download/v0.14.0/kserve.yaml
+kubectl apply --server-side -f https://github.com/kserve/kserve/releases/download/v0.14.0/kserve-cluster-resources.yaml
 
 # Wait for KServe
 kubectl wait --for=condition=available --timeout=300s -n kserve deployment/kserve-controller-manager

--- a/scripts/kind-cluster.sh
+++ b/scripts/kind-cluster.sh
@@ -9,7 +9,7 @@ set -e  # Exit on error
 
 # Configuration
 CLUSTER_NAME="neuralnav"
-KSERVE_VERSION="v0.13.0"
+KSERVE_VERSION="v0.14.0"
 CERT_MANAGER_VERSION="v1.14.4"
 CLUSTER_CONFIG="config/kind-cluster.yaml"
 
@@ -125,7 +125,7 @@ start_cluster() {
 
     # Install KServe
     print_step "Installing KServe ${KSERVE_VERSION}..."
-    kubectl apply -f "https://github.com/kserve/kserve/releases/download/${KSERVE_VERSION}/kserve.yaml"
+    kubectl apply --server-side -f "https://github.com/kserve/kserve/releases/download/${KSERVE_VERSION}/kserve.yaml"
 
     print_step "Waiting for KServe controller to be ready (this may take 2-3 minutes)..."
     kubectl wait --for=condition=available --timeout=300s \
@@ -143,7 +143,7 @@ start_cluster() {
 
     # Now apply cluster resources (requires webhook to be functional)
     print_step "Installing KServe cluster resources..."
-    kubectl apply -f "https://github.com/kserve/kserve/releases/download/${KSERVE_VERSION}/kserve-cluster-resources.yaml"
+    kubectl apply --server-side -f "https://github.com/kserve/kserve/releases/download/${KSERVE_VERSION}/kserve-cluster-resources.yaml"
     print_success "KServe cluster resources installed"
 
     # Configure KServe for RawDeployment mode

--- a/src/neuralnav/api/dependencies.py
+++ b/src/neuralnav/api/dependencies.py
@@ -62,6 +62,7 @@ def get_deployment_generator() -> DeploymentGenerator:
     global _deployment_generator
     if _deployment_generator is None:
         _deployment_generator = DeploymentGenerator(simulator_mode=False)
+        logger.info("Deployment generator initialized (simulator_mode=False)")
     return _deployment_generator
 
 
@@ -98,7 +99,7 @@ def get_cluster_manager(namespace: str = "default") -> KubernetesClusterManager 
             _cluster_manager = KubernetesClusterManager(namespace=namespace)
             logger.info("Kubernetes cluster manager initialized successfully")
         except KubernetesDeploymentError as e:
-            logger.warning(f"Kubernetes cluster not accessible: {e}")
+            logger.info(f"Kubernetes cluster not accessible: {e}")
             return None
     return _cluster_manager
 

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -278,6 +278,112 @@ def deploy_and_generate_yaml(recommendation: dict) -> dict | None:
 
 
 # =============================================================================
+# CLUSTER & DEPLOYMENT MANAGEMENT
+# =============================================================================
+
+
+def check_cluster_status() -> dict:
+    """Check if Kubernetes cluster is accessible.
+
+    Returns dict with 'accessible' bool and optional 'inference_services' list.
+    """
+    try:
+        response = requests.get(
+            f"{API_BASE_URL}/api/v1/cluster-status",
+            timeout=5,
+        )
+        if response.status_code == 200:
+            return response.json()
+        return {"accessible": False}
+    except Exception:
+        return {"accessible": False}
+
+
+def load_all_deployments() -> list | None:
+    """Load all InferenceServices from the cluster.
+
+    Returns list of deployment dicts, or None if cluster is not accessible.
+    """
+    try:
+        response = requests.get(
+            f"{API_BASE_URL}/api/v1/deployments",
+            timeout=DEFAULT_TIMEOUT,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            return data.get("deployments", [])
+        elif response.status_code == 503:
+            return None
+        else:
+            logger.error(f"Failed to load deployments: {response.text}")
+            return None
+    except requests.exceptions.ConnectionError:
+        return None
+    except Exception:
+        logger.exception("Error loading deployments")
+        return None
+
+
+def deploy_to_cluster(recommendation: dict, namespace: str = "default") -> dict:
+    """Deploy a recommendation to the Kubernetes cluster.
+
+    Returns dict with deployment_id, files, deployment_result, and success status.
+    """
+    try:
+        response = requests.post(
+            f"{API_BASE_URL}/api/v1/deploy-to-cluster",
+            json={"recommendation": recommendation, "namespace": namespace},
+            timeout=60,
+        )
+        if response.status_code == 200:
+            return response.json()
+        elif response.status_code == 503:
+            return {"success": False, "message": "Kubernetes cluster not accessible"}
+        else:
+            return {"success": False, "message": response.text}
+    except requests.exceptions.ConnectionError:
+        return {"success": False, "message": "Cannot connect to backend API"}
+    except Exception as e:
+        return {"success": False, "message": str(e)}
+
+
+def delete_deployment(deployment_id: str) -> dict:
+    """Delete a deployment from the cluster.
+
+    Returns dict with 'success' bool and 'message'.
+    """
+    try:
+        response = requests.delete(
+            f"{API_BASE_URL}/api/v1/deployments/{deployment_id}",
+            timeout=30,
+        )
+        if response.status_code == 200:
+            return response.json()
+        else:
+            return {"success": False, "message": response.text}
+    except Exception as e:
+        return {"success": False, "message": str(e)}
+
+
+def get_k8s_status(deployment_id: str) -> dict | None:
+    """Get real Kubernetes status for a deployment.
+
+    Returns dict with inferenceservice status, pods, etc., or None on error.
+    """
+    try:
+        response = requests.get(
+            f"{API_BASE_URL}/api/v1/deployments/{deployment_id}/k8s-status",
+            timeout=DEFAULT_TIMEOUT,
+        )
+        if response.status_code == 200:
+            return response.json()
+        return None
+    except Exception as e:
+        logger.error(f"Failed to get K8s status for {deployment_id}: {e}")
+        return None
+
+
+# =============================================================================
 # DEPLOYMENT MODE
 # =============================================================================
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -25,6 +25,7 @@ from api_client import (
     load_206_models,
 )
 from components.deployment import render_deployment_tab
+from components.deployment_management import render_deployment_management_tab
 from components.dialogs import (
     show_category_dialog,
     show_full_table_dialog,
@@ -510,9 +511,9 @@ def main():
     # Main Content - Compact hero
     render_hero()
 
-    # Tab-based navigation (5 tabs)
-    tab1, tab2, tab3, tab4, tab5 = st.tabs(
-        ["Define Use Case", "Technical Specification", "Recommendations", "Deployment", "Configuration"]
+    # Tab-based navigation (6 tabs)
+    tab1, tab2, tab3, tab4, tab5, tab6 = st.tabs(
+        ["Define Use Case", "Technical Specification", "Recommendations", "Deployment", "Deployment Management", "Configuration"]
     )
 
     with tab1:
@@ -528,6 +529,9 @@ def main():
         render_deployment_tab()
 
     with tab5:
+        render_deployment_management_tab()
+
+    with tab6:
         render_configuration_tab()
 
     # Auto-switch to pending tab after rerun

--- a/ui/components/deployment.py
+++ b/ui/components/deployment.py
@@ -8,7 +8,7 @@ import zipfile
 
 import requests
 import streamlit as st
-from api_client import API_BASE_URL
+from api_client import API_BASE_URL, check_cluster_status, deploy_to_cluster
 
 
 def render_deployment_tab():
@@ -57,6 +57,11 @@ def render_deployment_tab():
     """,
         unsafe_allow_html=True,
     )
+
+    # Deploy to Kubernetes button
+    _render_deploy_to_cluster_button(selected_config)
+
+    st.markdown("---")
 
     # YAML Generation Section
     if not st.session_state.get("deployment_yaml_generated"):
@@ -169,3 +174,44 @@ def render_deployment_tab():
             st.session_state.deployment_id = None
             st.session_state.deployment_error = None
             st.rerun()
+
+
+def _render_deploy_to_cluster_button(selected_config: dict):
+    """Render the Deploy to Kubernetes button with cluster status check on click."""
+    already_deployed = st.session_state.get("deployed_to_cluster", False)
+
+    if st.button(
+        "Deployed to Cluster" if already_deployed else "Deploy to Kubernetes",
+        use_container_width=True,
+        type="primary",
+        disabled=already_deployed,
+        help="Already deployed to cluster" if already_deployed else "Deploy to Kubernetes cluster (YAML auto-generated)",
+        key="deploy_to_cluster_btn",
+    ):
+        # Check cluster accessibility when the user clicks
+        with st.spinner("Checking cluster connectivity..."):
+            status = check_cluster_status()
+        if not status.get("accessible", False):
+            st.error("Kubernetes cluster is not accessible. Please ensure the cluster is running and try again.")
+            return
+
+        with st.spinner("Deploying to Kubernetes cluster..."):
+            result = deploy_to_cluster(selected_config)
+
+        if result.get("success") or result.get("deployment_id"):
+            st.session_state.deployed_to_cluster = True
+            st.session_state.deployment_id = result.get("deployment_id")
+
+            # Store YAML files if returned
+            files = result.get("files", {})
+            if files:
+                st.session_state.deployment_yaml_files = files
+                st.session_state.deployment_yaml_generated = True
+
+            st.success(f"Successfully deployed to cluster! Deployment ID: `{result.get('deployment_id')}`")
+
+            deployment_result = result.get("deployment_result", {})
+            for applied_file in deployment_result.get("applied_files", []):
+                st.markdown(f"- {applied_file['file']}")
+        else:
+            st.error(f"Deployment failed: {result.get('message', 'Unknown error')}")

--- a/ui/components/deployment_management.py
+++ b/ui/components/deployment_management.py
@@ -1,0 +1,316 @@
+"""Deployment Management tab component for the NeuralNav UI.
+
+Lists cluster deployments, shows K8s status, provides delete and inference testing.
+"""
+
+import json
+import subprocess
+import time
+
+import pandas as pd
+import streamlit as st
+from api_client import delete_deployment, get_k8s_status, load_all_deployments
+
+
+def render_deployment_management_tab():
+    """Tab 5: Deployment Management — list, inspect, test, and delete cluster deployments."""
+    st.subheader("Cluster Deployments")
+
+    all_deployments = load_all_deployments()
+
+    if all_deployments is None:
+        st.warning("Could not connect to cluster to list deployments")
+        st.info(
+            "**Troubleshooting:**\n"
+            "- Ensure Kubernetes cluster is running (e.g., KIND cluster)\n"
+            "- Check that kubectl can access the cluster: `kubectl cluster-info`\n"
+            "- Verify backend API is running on http://localhost:8000"
+        )
+        return
+
+    if len(all_deployments) == 0:
+        st.info(
+            "**No deployments found in cluster**\n\n"
+            "To create a deployment:\n"
+            "1. Go to the **Recommendations** tab and select a configuration\n"
+            "2. Go to the **Deployment** tab\n"
+            "3. Click **Deploy to Kubernetes**"
+        )
+        return
+
+    # Deployments table
+    st.markdown(f"**Found {len(all_deployments)} deployment(s)**")
+
+    table_data = []
+    for dep in all_deployments:
+        status = dep.get("status", {})
+        pods = dep.get("pods", [])
+        ready = status.get("ready", False)
+        table_data.append({
+            "Status": "Ready" if ready else "Pending",
+            "Name": dep["deployment_id"],
+            "Pods": len(pods),
+            "Ready": "Yes" if ready else "No",
+        })
+
+    df = pd.DataFrame(table_data)
+    st.dataframe(df, use_container_width=True, hide_index=True)
+
+    st.markdown("---")
+    st.markdown("### Select Deployment to Manage")
+
+    # Deployment selector
+    deployment_options = {d["deployment_id"]: d for d in all_deployments}
+    deployment_ids = list(deployment_options.keys())
+
+    if (
+        st.session_state.selected_deployment is None
+        or st.session_state.selected_deployment not in deployment_ids
+    ):
+        st.session_state.selected_deployment = deployment_ids[0] if deployment_ids else None
+
+    col1, col2 = st.columns([3, 1])
+    with col1:
+        selected = st.selectbox(
+            "Choose a deployment:",
+            deployment_ids,
+            index=deployment_ids.index(st.session_state.selected_deployment)
+            if st.session_state.selected_deployment in deployment_ids
+            else 0,
+            key="deployment_selector_mgmt",
+        )
+        st.session_state.selected_deployment = selected
+
+    with col2:
+        st.markdown("<br>", unsafe_allow_html=True)
+        if st.button("Refresh", use_container_width=True, key="refresh_mgmt"):
+            st.rerun()
+
+    if not st.session_state.selected_deployment:
+        return
+
+    deployment_info = deployment_options[st.session_state.selected_deployment]
+
+    st.markdown("---")
+    _render_deployment_controls(deployment_info)
+    st.markdown("---")
+    _render_k8s_status(deployment_info)
+    st.markdown("---")
+    _render_inference_testing(deployment_info)
+
+
+def _render_deployment_controls(deployment_info: dict):
+    """Render deployment status metrics and delete button."""
+    deployment_id = deployment_info["deployment_id"]
+    status = deployment_info.get("status", {})
+    pods = deployment_info.get("pods", [])
+
+    st.markdown("#### Deployment Management")
+
+    col1, col2, col3 = st.columns(3)
+
+    with col1:
+        ready_status = "Ready" if status.get("ready") else "Pending"
+        st.metric("Status", ready_status)
+
+    with col2:
+        st.metric("Pods", len(pods))
+
+    with col3:
+        confirm_key = f"confirm_delete_{deployment_id}"
+        if st.button(
+            "Delete Deployment",
+            use_container_width=True,
+            type="secondary",
+            key=f"delete_btn_{deployment_id}",
+        ):
+            if st.session_state.get(confirm_key):
+                with st.spinner("Deleting deployment..."):
+                    result = delete_deployment(deployment_id)
+                if result.get("success"):
+                    st.success(f"Deleted {deployment_id}")
+                    if st.session_state.deployment_id == deployment_id:
+                        st.session_state.deployment_id = None
+                        st.session_state.deployed_to_cluster = False
+                    st.session_state[confirm_key] = False
+                    time.sleep(1)
+                    st.rerun()
+                else:
+                    st.error(f"Failed to delete: {result.get('message', 'Unknown error')}")
+                    st.session_state[confirm_key] = False
+            else:
+                st.session_state[confirm_key] = True
+                st.warning(f"Click again to confirm deletion of {deployment_id}")
+
+
+def _render_k8s_status(deployment_info: dict):
+    """Render Kubernetes status for a deployment."""
+    deployment_id = deployment_info["deployment_id"]
+    status = deployment_info.get("status", {})
+    pods = deployment_info.get("pods", [])
+
+    st.markdown("#### Kubernetes Status")
+
+    if status.get("exists"):
+        st.success(f"InferenceService: **{deployment_id}**")
+        st.markdown(f"**Ready:** {'Yes' if status.get('ready') else 'Not yet'}")
+
+        if status.get("url"):
+            st.markdown(f"**URL:** `{status['url']}`")
+
+        with st.expander("Resource Conditions"):
+            for condition in status.get("conditions", []):
+                status_icon = "+" if condition.get("status") == "True" else "-"
+                st.markdown(
+                    f"[{status_icon}] **{condition.get('type')}**: {condition.get('message', 'N/A')}"
+                )
+    else:
+        st.warning(f"InferenceService not found: {status.get('error', 'Unknown error')}")
+
+    if pods:
+        st.markdown(f"**Pods:** {len(pods)} pod(s)")
+        with st.expander("Pod Details"):
+            for pod in pods:
+                st.markdown(f"**{pod.get('name')}**")
+                st.markdown(f"- Phase: {pod.get('phase')}")
+                node_name = pod.get("node_name") or "Not assigned"
+                st.markdown(f"- Node: {node_name}")
+    else:
+        st.info("No pods found yet (may still be creating)")
+
+
+def _render_inference_testing(deployment_info: dict):
+    """Render inference testing UI for a deployment."""
+    deployment_id = deployment_info["deployment_id"]
+    status = deployment_info.get("status", {})
+
+    st.markdown("#### Inference Testing")
+
+    if not status.get("ready"):
+        st.info(
+            "Deployment not ready yet. Inference testing will be available once the service is ready."
+        )
+        return
+
+    col1, col2 = st.columns([2, 1])
+    with col1:
+        test_prompt = st.text_area(
+            "Test Prompt",
+            value="Write a Python function that calculates the fibonacci sequence.",
+            height=100,
+            key=f"test_prompt_{deployment_id}",
+        )
+
+    with col2:
+        max_tokens = st.number_input(
+            "Max Tokens",
+            value=150,
+            min_value=10,
+            max_value=500,
+            key=f"max_tokens_{deployment_id}",
+        )
+        temperature = st.slider(
+            "Temperature", 0.0, 2.0, 0.7, 0.1, key=f"temperature_{deployment_id}"
+        )
+
+    if st.button(
+        "Send Test Request",
+        use_container_width=True,
+        key=f"test_button_{deployment_id}",
+    ):
+        _run_inference_test(deployment_id, test_prompt, max_tokens, temperature)
+
+    with st.expander("How Inference Testing Works"):
+        st.markdown(
+            "**Process:**\n"
+            "1. Uses `kubectl port-forward` to connect to the InferenceService\n"
+            "2. Sends a POST request to `/v1/completions` (OpenAI-compatible API)\n"
+            "3. Displays the response and metrics\n\n"
+            "**Note:** This temporarily forwards port 8080 on your local machine to the service."
+        )
+
+
+def _run_inference_test(deployment_id: str, prompt: str, max_tokens: int, temperature: float):
+    """Execute an inference test via kubectl port-forward."""
+    with st.spinner("Sending inference request..."):
+        service_name = f"{deployment_id}-predictor"
+        st.info(f"Connecting to service: `{service_name}`")
+
+        port_forward_proc = subprocess.Popen(
+            ["kubectl", "port-forward", f"svc/{service_name}", "8080:80"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        time.sleep(3)
+
+        if port_forward_proc.poll() is not None:
+            pf_stdout, pf_stderr = port_forward_proc.communicate()
+            st.error("Port-forward failed to start")
+            st.code(
+                f"stdout: {pf_stdout.decode()}\nstderr: {pf_stderr.decode()}",
+                language="text",
+            )
+            return
+
+        try:
+            start_time = time.time()
+
+            curl_cmd = [
+                "curl", "-s", "-X", "POST",
+                "http://localhost:8080/v1/completions",
+                "-H", "Content-Type: application/json",
+                "-d", json.dumps({
+                    "prompt": prompt,
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                }),
+            ]
+
+            with st.expander("Debug Info"):
+                st.code(" ".join(curl_cmd), language="bash")
+
+            result = subprocess.run(curl_cmd, capture_output=True, text=True, timeout=30)
+            elapsed_time = time.time() - start_time
+
+            if result.returncode == 0 and result.stdout:
+                try:
+                    response_data = json.loads(result.stdout)
+                    st.success(f"Response received in {elapsed_time:.2f}s")
+
+                    st.markdown("**Generated Response:**")
+                    response_text = response_data.get("choices", [{}])[0].get("text", "")
+                    st.code(response_text, language=None)
+
+                    usage = response_data.get("usage", {})
+                    c1, c2, c3 = st.columns(3)
+                    with c1:
+                        st.metric("Prompt Tokens", usage.get("prompt_tokens", 0))
+                    with c2:
+                        st.metric("Completion Tokens", usage.get("completion_tokens", 0))
+                    with c3:
+                        st.metric("Total Tokens", usage.get("total_tokens", 0))
+
+                    st.metric("Total Latency", f"{elapsed_time:.2f}s")
+
+                    with st.expander("Raw API Response"):
+                        st.json(response_data)
+
+                except json.JSONDecodeError as e:
+                    st.error(f"Failed to parse JSON response: {e}")
+                    st.code(result.stdout, language="text")
+            else:
+                st.error(f"Request failed (return code: {result.returncode})")
+                if result.stdout:
+                    st.code(result.stdout, language="text")
+                if result.stderr:
+                    st.code(result.stderr, language="text")
+
+        except subprocess.TimeoutExpired:
+            st.error("Request timed out (30s). The model may still be starting up.")
+        finally:
+            port_forward_proc.terminate()
+            try:
+                port_forward_proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                port_forward_proc.kill()

--- a/ui/components/recommendations.py
+++ b/ui/components/recommendations.py
@@ -114,6 +114,7 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
                     st.session_state.deployment_yaml_files = {}
                     st.session_state.deployment_id = None
                     st.session_state.deployment_error = None
+                    st.session_state.deployed_to_cluster = False
                     st.rerun()
             with nav_label:
                 st.markdown(
@@ -129,6 +130,7 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
                     st.session_state.deployment_yaml_files = {}
                     st.session_state.deployment_id = None
                     st.session_state.deployment_error = None
+                    st.session_state.deployed_to_cluster = False
                     st.rerun()
 
         selected_category = st.session_state.get("deployment_selected_category")
@@ -144,6 +146,7 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
                 st.session_state.deployment_yaml_files = {}
                 st.session_state.deployment_id = None
                 st.session_state.deployment_error = None
+                st.session_state.deployed_to_cluster = False
                 st.rerun()
         else:
             if st.button("Select", key=f"select_{category_key}", use_container_width=True):
@@ -152,6 +155,7 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
                 st.session_state.deployment_yaml_generated = False
                 st.session_state.deployment_yaml_files = {}
                 st.session_state.deployment_id = None
+                st.session_state.deployed_to_cluster = False
 
                 result = deploy_and_generate_yaml(rec)
                 if result and result.get("success"):

--- a/ui/components/settings.py
+++ b/ui/components/settings.py
@@ -14,7 +14,7 @@ from api_client import (
 )
 
 
-_TAB_INDEX = 4  # Configuration is the 5th tab (0-indexed)
+_TAB_INDEX = 5  # Configuration is the 6th tab (0-indexed)
 
 
 def render_configuration_tab():
@@ -22,27 +22,41 @@ def render_configuration_tab():
     # --- Deployment Mode ---
     st.subheader("Deployment Mode")
 
+    # Sync deployment mode from backend on each render
     current_mode = fetch_deployment_mode()
-    modes = ["Production", "Simulator"]
-    current_index = 1 if current_mode == "simulator" else 0
+    st.session_state.deployment_mode_selection = (
+        "Simulator" if current_mode == "simulator" else "Production"
+    )
 
-    selected = st.radio(
+    def _on_mode_change():
+        new_mode = st.session_state.deployment_mode_radio.lower()
+        result = update_deployment_mode(new_mode)
+        if result:
+            st.session_state.deployment_mode_selection = st.session_state.deployment_mode_radio
+            st.session_state["_mode_msg"] = ("success", f"Deployment mode set to **{st.session_state.deployment_mode_radio}**.")
+        else:
+            st.session_state["_mode_msg"] = ("error", "Failed to update deployment mode.")
+        st.session_state["_pending_tab"] = _TAB_INDEX
+
+    modes = ["Production", "Simulator"]
+    st.radio(
         "YAML generation target",
         modes,
-        index=current_index,
+        index=modes.index(st.session_state.deployment_mode_selection),
         horizontal=True,
         key="deployment_mode_radio",
+        on_change=_on_mode_change,
         help="Production uses real vLLM with GPU resources. "
         "Simulator uses the vLLM simulator (no GPU required).",
     )
 
-    selected_mode = selected.lower()
-    if current_mode and selected_mode != current_mode:
-        result = update_deployment_mode(selected_mode)
-        if result:
-            st.success(f"Deployment mode set to **{selected}**.")
+    mode_msg = st.session_state.pop("_mode_msg", None)
+    if mode_msg:
+        level, text = mode_msg
+        if level == "success":
+            st.success(text)
         else:
-            st.error("Failed to update deployment mode.")
+            st.error(text)
 
     st.divider()
 

--- a/ui/state.py
+++ b/ui/state.py
@@ -53,6 +53,10 @@ SESSION_DEFAULTS = {
     "deployment_yaml_files": {},
     "deployment_id": None,
     "deployment_yaml_generated": False,
+    # Cluster / deployment management
+    "cluster_accessible": None,
+    "deployed_to_cluster": False,
+    "selected_deployment": None,
 }
 # Ranking weights are initialized in the PRIORITIES section of the Tech Spec tab
 # using values from priority_weights.json. Do NOT hardcode defaults here.


### PR DESCRIPTION
Support for deploying a selected solution to Kubernetes was deleted from the 
UI during the big merge, but the backend code remained.  This PR adds the UI back.  

There is no intent for this support to replace production-grade deployment management, 
but it can be very useful both for testing the config files that we generate, and also
for the user to quickly test the recommended solutions.

- Add Deploy to Kubernetes button on the Deployment tab.
- Restore deployment management UI with cluster deployment listing,
  K8s status monitoring, delete controls, and inference testing.
- Fix KServe v0.13.0 to v0.14.0 upgrade and settings tab selector bugs.

Unrelated fix:
- make setup should install optional UI and dev dependencies



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment Management tab for viewing, managing, and testing cluster deployments
  * Deploy-to-cluster button to push configurations to Kubernetes from the UI
  * Inference testing that runs request/response checks against deployed services

* **Improvements**
  * Kubernetes status, pod details, and deployment lifecycle surfaced in UI
  * Enhanced cluster connectivity checks, clearer error messaging, and persisted deployment state
  * Configuration tab reordered for smoother workflow

* **Chores**
  * KIND/KServe setup updated to a newer release and uses server-side apply; backend setup now syncs UI and dev components during initialization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->