### PR TITLE
Return YAML contents inline from deploy API, remove /yaml endpoint

### DIFF
--- a/src/planner/api/routes/configuration.py
+++ b/src/planner/api/routes/configuration.py
@@ -1,6 +1,5 @@
 """Configuration and deployment endpoints."""
 
-import glob as glob_module
 import logging
 import random
 from datetime import datetime
@@ -81,27 +80,14 @@ async def deploy_model(
     deployment_generator: DeploymentGenerator = Depends(get_deployment_generator),
     yaml_validator: YAMLValidator = Depends(get_yaml_validator),
 ):
-    """
-    Generate deployment YAML files from recommendation.
-
-    Args:
-        request: Deployment request with recommendation
-
-    Returns:
-        Deployment response with file paths
-
-    Raises:
-        HTTPException: If deployment generation fails
-    """
+    """Generate deployment YAML and return contents inline."""
     try:
         logger.info(f"Generating deployment for model: {request.recommendation.model_name}")
 
-        # Generate all YAML files
         result = deployment_generator.generate_all(
             recommendation=request.recommendation, namespace=request.namespace
         )
 
-        # Validate generated files
         try:
             yaml_validator.validate_all(result["files"])
             logger.info(f"All YAML files validated for deployment: {result['deployment_id']}")
@@ -115,11 +101,13 @@ async def deploy_model(
         return DeploymentResponse(
             deployment_id=result["deployment_id"],
             namespace=result["namespace"],
-            files=result["files"],
+            files=result["contents"],
             success=True,
             message=f"Deployment files generated successfully for {result['deployment_id']}",
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Failed to generate deployment: {e}", exc_info=True)
         raise HTTPException(
@@ -278,7 +266,7 @@ async def deploy_to_cluster(
             "success": True,
             "deployment_id": deployment_id,
             "namespace": request.namespace,
-            "files": files,
+            "files": result["contents"],
             "deployment_result": deployment_result,
             "message": f"Successfully deployed {deployment_id} to Kubernetes cluster",
         }
@@ -355,50 +343,6 @@ async def get_k8s_deployment_status(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to get deployment status: {str(e)}",
-        ) from e
-
-
-@router.get("/deployments/{deployment_id}/yaml")
-async def get_deployment_yaml(
-    deployment_id: str,
-    deployment_generator: DeploymentGenerator = Depends(get_deployment_generator),
-):
-    """
-    Retrieve generated YAML files for a deployment.
-
-    Args:
-        deployment_id: Deployment identifier
-
-    Returns:
-        Dictionary with YAML file contents
-
-    Raises:
-        HTTPException: If YAML files not found
-    """
-    try:
-        output_dir = deployment_generator.output_dir
-
-        yaml_files = {}
-        safe_id = glob_module.escape(deployment_id)
-        for file_path in output_dir.glob(f"{safe_id}*.yaml"):
-            with open(file_path) as f:
-                yaml_files[file_path.name] = f.read()
-
-        if not yaml_files:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"No YAML files found for deployment {deployment_id}",
-            )
-
-        return {"deployment_id": deployment_id, "files": yaml_files, "count": len(yaml_files)}
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to retrieve YAML files: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to retrieve YAML files: {str(e)}",
         ) from e
 
 

--- a/src/planner/api/routes/configuration.py
+++ b/src/planner/api/routes/configuration.py
@@ -34,7 +34,7 @@ class DeploymentResponse(BaseModel):
 
     deployment_id: str
     namespace: str
-    files: dict[str, Any]
+    yaml_contents: dict[str, Any]
     success: bool = True
     message: str | None = None
 
@@ -101,7 +101,7 @@ async def deploy_model(
         return DeploymentResponse(
             deployment_id=result["deployment_id"],
             namespace=result["namespace"],
-            files=result["contents"],
+            yaml_contents=result["contents"],
             success=True,
             message=f"Deployment files generated successfully for {result['deployment_id']}",
         )
@@ -235,11 +235,11 @@ async def deploy_to_cluster(
         )
 
         deployment_id = result["deployment_id"]
-        files = result["files"]
+        file_paths = result["files"]
 
         # Step 2: Validate generated files
         try:
-            yaml_validator.validate_all(files)
+            yaml_validator.validate_all(file_paths)
             logger.info(f"YAML validation passed for: {deployment_id}")
         except Exception as e:
             logger.error(f"YAML validation failed: {e}")
@@ -249,7 +249,7 @@ async def deploy_to_cluster(
             ) from e
 
         # Step 3: Deploy to cluster
-        yaml_file_paths = [files["inferenceservice"], files["autoscaling"]]
+        yaml_file_paths = [file_paths["inferenceservice"], file_paths["autoscaling"]]
 
         deployment_result = await run_in_threadpool(manager.deploy_all, yaml_file_paths)
 
@@ -266,7 +266,7 @@ async def deploy_to_cluster(
             "success": True,
             "deployment_id": deployment_id,
             "namespace": request.namespace,
-            "files": result["contents"],
+            "yaml_contents": result["contents"],
             "deployment_result": deployment_result,
             "message": f"Successfully deployed {deployment_id} to Kubernetes cluster",
         }

--- a/src/planner/api/routes/recommendation.py
+++ b/src/planner/api/routes/recommendation.py
@@ -102,22 +102,22 @@ def simple_recommend(
                     recommendation=recommendation, namespace="default"
                 )
                 deployment_id = yaml_result["deployment_id"]
-                yaml_files: dict = yaml_result["files"]
+                yaml_contents: dict = yaml_result["contents"]
                 logger.info(
-                    f"Auto-generated YAML files for {deployment_id}: {list(yaml_files.keys())}"
+                    f"Auto-generated YAML for {deployment_id}: {list(yaml_contents.keys())}"
                 )
                 yaml_generated = True
             except Exception as yaml_error:
                 logger.warning(f"Failed to auto-generate YAML: {yaml_error}")
                 deployment_id = None
-                yaml_files = {}
+                yaml_contents = {}
                 yaml_generated = False
 
             # Return recommendation as dict with YAML info
             result = recommendation.model_dump()
             result["deployment_id"] = deployment_id
             result["yaml_generated"] = yaml_generated
-            result["yaml_files"] = list(yaml_files.keys()) if yaml_files else []
+            result["yaml_files"] = yaml_contents
 
             return result
 
@@ -147,7 +147,7 @@ def simple_recommend(
             result = partial_recommendation.model_dump()
             result["deployment_id"] = None
             result["yaml_generated"] = False
-            result["yaml_files"] = []
+            result["yaml_files"] = {}
 
             return result
 

--- a/src/planner/configuration/generator.py
+++ b/src/planner/configuration/generator.py
@@ -249,12 +249,13 @@ class DeploymentGenerator:
             namespace: Kubernetes namespace
 
         Returns:
-            Dictionary with deployment_id, namespace, files, and metadata
+            Dictionary with deployment_id, namespace, files (paths), and contents (rendered YAML)
         """
         deployment_id = self.generate_deployment_id(recommendation)
         context = self._prepare_template_context(recommendation, deployment_id, namespace)
 
         generated_files = {}
+        generated_contents = {}
 
         # Generate each config file
         configs = [
@@ -275,6 +276,7 @@ class DeploymentGenerator:
                 # Extract config type from template name (remove .j2 suffix)
                 config_type = template_name.replace(".yaml.j2", "").replace("kserve-", "")
                 generated_files[config_type] = str(output_path)
+                generated_contents[config_type] = rendered
 
                 logger.info(f"Generated {config_type}: {output_path}")
 
@@ -282,20 +284,11 @@ class DeploymentGenerator:
                 logger.error(f"Failed to generate {template_name}: {e}")
                 raise
 
-        # Store deployment metadata
-        metadata = {
-            "deployment_id": deployment_id,
-            "namespace": namespace,
-            "generated_at": context["generated_at"],
-            "files": generated_files,
-            "recommendation": recommendation.model_dump(),
-        }
-
         return {
             "deployment_id": deployment_id,
             "namespace": namespace,
             "files": generated_files,
-            "metadata": metadata,
+            "contents": generated_contents,
         }
 
     def generate_kserve_yaml(

--- a/tests/test_yaml_generation.py
+++ b/tests/test_yaml_generation.py
@@ -90,6 +90,13 @@ def test_yaml_generation():
     assert result is not None
     assert "deployment_id" in result
     assert "files" in result
+    assert "contents" in result
+
+    # Verify contents keys match files keys and contain YAML strings
+    assert set(result["contents"]) == set(result["files"])
+    for config_type, content in result["contents"].items():
+        assert isinstance(content, str), f"Expected string content for {config_type}"
+        assert len(content) > 0, f"Empty YAML content for {config_type}"
 
     # Step 3: Validate generated YAMLs
     validator = YAMLValidator()

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -431,9 +431,9 @@ def extract_business_context(user_input: str) -> dict | None:
 
 
 def deploy_and_generate_yaml(recommendation: dict) -> dict | None:
-    """Deploy a recommendation and fetch generated YAML files.
+    """Deploy a recommendation and return generated YAML contents.
 
-    Returns dict with deployment_id, files, and success status, or None on error.
+    Returns dict with deployment_id, files (YAML contents), and success status, or None on error.
     """
     try:
         response = requests.post(
@@ -444,17 +444,10 @@ def deploy_and_generate_yaml(recommendation: dict) -> dict | None:
         response.raise_for_status()
         result = response.json()
         if result.get("success"):
-            deployment_id = result.get("deployment_id")
-            yaml_response = requests.get(
-                f"{API_BASE_URL}/api/v1/deployments/{deployment_id}/yaml",
-                timeout=DEFAULT_TIMEOUT,
-            )
-            yaml_response.raise_for_status()
-            yaml_data = yaml_response.json()
             return {
                 "success": True,
-                "deployment_id": deployment_id,
-                "files": yaml_data.get("files", {}),
+                "deployment_id": result.get("deployment_id"),
+                "files": result.get("files", {}),
             }
         else:
             return {"success": False, "message": result.get("message", "Unknown error")}

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -433,7 +433,7 @@ def extract_business_context(user_input: str) -> dict | None:
 def deploy_and_generate_yaml(recommendation: dict) -> dict | None:
     """Deploy a recommendation and return generated YAML contents.
 
-    Returns dict with deployment_id, files (YAML contents), and success status, or None on error.
+    Returns dict with deployment_id, yaml_contents, and success status, or None on error.
     """
     try:
         response = requests.post(
@@ -447,7 +447,7 @@ def deploy_and_generate_yaml(recommendation: dict) -> dict | None:
             return {
                 "success": True,
                 "deployment_id": result.get("deployment_id"),
-                "files": result.get("files", {}),
+                "yaml_contents": result.get("yaml_contents", {}),
             }
         else:
             return {"success": False, "message": result.get("message", "Unknown error")}
@@ -505,7 +505,7 @@ def load_all_deployments() -> list | None:
 def deploy_to_cluster(recommendation: dict, namespace: str = "default") -> dict:
     """Deploy a recommendation to the Kubernetes cluster.
 
-    Returns dict with deployment_id, files, deployment_result, and success status.
+    Returns dict with deployment_id, yaml_contents, deployment_result, and success status.
     """
     try:
         response = requests.post(

--- a/ui/components/deployment.py
+++ b/ui/components/deployment.py
@@ -83,17 +83,8 @@ def render_deployment_tab():
                     result = response.json()
 
                     if result.get("success"):
-                        deployment_id = result.get("deployment_id")
-                        st.session_state.deployment_id = deployment_id
-
-                        yaml_response = requests.get(
-                            f"{API_BASE_URL}/api/v1/deployments/{deployment_id}/yaml",
-                            timeout=10,
-                        )
-                        yaml_response.raise_for_status()
-                        yaml_data = yaml_response.json()
-
-                        st.session_state.deployment_yaml_files = yaml_data.get("files", {})
+                        st.session_state.deployment_id = result.get("deployment_id")
+                        st.session_state.deployment_yaml_files = result.get("files", {})
                         st.session_state.deployment_yaml_generated = True
                         st.rerun()
                     else:
@@ -117,7 +108,8 @@ def render_deployment_tab():
         if yaml_files:
             zip_buffer = io.BytesIO()
             with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-                for filename, content in yaml_files.items():
+                for config_type, content in yaml_files.items():
+                    filename = f"{deployment_id}-{config_type}.yaml"
                     zf.writestr(filename, content)
             zip_buffer.seek(0)
 

--- a/ui/components/deployment.py
+++ b/ui/components/deployment.py
@@ -84,7 +84,7 @@ def render_deployment_tab():
 
                     if result.get("success"):
                         st.session_state.deployment_id = result.get("deployment_id")
-                        st.session_state.deployment_yaml_files = result.get("files", {})
+                        st.session_state.deployment_yaml_files = result.get("yaml_contents", {})
                         st.session_state.deployment_yaml_generated = True
                         st.rerun()
                     else:
@@ -198,10 +198,10 @@ def _render_deploy_to_cluster_button(selected_config: dict):
             st.session_state.deployed_to_cluster = True
             st.session_state.deployment_id = result.get("deployment_id")
 
-            # Store YAML files if returned
-            files = result.get("files", {})
-            if files:
-                st.session_state.deployment_yaml_files = files
+            # Store YAML contents if returned
+            yaml_contents = result.get("yaml_contents", {})
+            if yaml_contents:
+                st.session_state.deployment_yaml_files = yaml_contents
                 st.session_state.deployment_yaml_generated = True
 
             st.success(

--- a/ui/components/recommendations.py
+++ b/ui/components/recommendations.py
@@ -244,7 +244,7 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
                 result = deploy_and_generate_yaml(rec)
                 if result and result.get("success"):
                     st.session_state.deployment_id = result["deployment_id"]
-                    st.session_state.deployment_yaml_files = result["files"]
+                    st.session_state.deployment_yaml_files = result["yaml_contents"]
                     st.session_state.deployment_yaml_generated = True
                 else:
                     st.session_state.deployment_yaml_generated = False


### PR DESCRIPTION
## Description

The deploy endpoints previously returned internal file paths in the response, requiring a second `GET /deployments/{id}/yaml` round-trip to fetch the actual YAML contents. This leaked backend implementation details and added unnecessary latency for API consumers (including the MCP integration).

`generate_all()` now captures rendered YAML strings at template render time and returns them in a `contents` key. All three endpoints that call it (`/deploy`, `/deploy-to-cluster`, `/recommend`) return YAML content directly. The `GET /deployments/{id}/yaml` endpoint has been removed.

## Main changes:
- `generator.py`: `generate_all()` returns a `contents` dict alongside `files`
- `configuration.py`: `/deploy` and `/deploy-to-cluster` return `contents`; `GET /deployments/{id}/yaml` removed
- `recommendation.py`: `/recommend` returns `contents` instead of file paths; error path returns `{}` instead of `[]` for type consistency
- `api_client.py`: Remove second GET round-trip
- `deployment.py`: Remove second GET round-trip; zip download entries use proper filenames (`{deployment_id}-{type}.yaml`)

## How has this been tested?

- `test_yaml_generation.py` updated to assert `contents` key exists, its keys match `files`, and each value is a non-empty YAML string
- Full non-DB test suite passes (`uv run pytest -q`)
- `mypy` and `ruff clean` on all changed files across all commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deployment responses now include generated YAML contents directly, removing the need for a follow-up fetch and reducing API round-trips.
  * UI now obtains YAML from the initial deploy response and packages downloads with filenames that include the deployment ID and config type.
* **Bug Fixes**
  * Existing HTTP errors during deploy now propagate unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->