### PR TITLE
feat: integrate estimated performance into recommendation pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,17 +469,17 @@ db-remove: db-stop ## Stop and remove PostgreSQL container
 
 db-load-blis: db-start ## Load BLIS benchmark data (appends)
 	@printf "$(BLUE)Loading BLIS benchmark data...$(NC)\n"
-	@uv run python scripts/load_benchmarks.py data/benchmarks/performance/benchmarks_BLIS.json
+	@uv run python scripts/load_benchmarks.py data/benchmarks/performance/benchmarks_BLIS.json --source blis --confidence-level benchmarked
 	@printf "$(GREEN)✓ BLIS data loaded$(NC)\n"
 
 db-load-estimated: db-start ## Load estimated performance benchmarks (appends)
 	@printf "$(BLUE)Loading estimated performance data...$(NC)\n"
-	@uv run python scripts/load_benchmarks.py data/benchmarks/performance/benchmarks_estimated_performance.json
+	@uv run python scripts/load_benchmarks.py data/benchmarks/performance/benchmarks_estimated_performance.json --source manual --confidence-level estimated
 	@printf "$(GREEN)✓ Estimated data loaded$(NC)\n"
 
 db-load-interpolated: db-start ## Load interpolated benchmark data (appends)
 	@printf "$(BLUE)Loading interpolated benchmark data...$(NC)\n"
-	@uv run python scripts/load_benchmarks.py data/benchmarks/performance/benchmarks_interpolated_v2.json
+	@uv run python scripts/load_benchmarks.py data/benchmarks/performance/benchmarks_interpolated_v2.json --source manual --confidence-level estimated
 	@printf "$(GREEN)✓ Interpolated data loaded$(NC)\n"
 
 db-load-guidellm: db-start ## Load GuideLLM benchmark data (appends)
@@ -489,7 +489,7 @@ db-load-guidellm: db-start ## Load GuideLLM benchmark data (appends)
 		printf "$(YELLOW)Run 'make db-convert-pgdump' first to create it from a pg_dump file$(NC)\n"; \
 		exit 1; \
 	fi
-	@uv run python scripts/load_benchmarks.py data/benchmarks/performance/benchmarks_GuideLLM.json
+	@uv run python scripts/load_benchmarks.py data/benchmarks/performance/benchmarks_GuideLLM.json --source guidellm --confidence-level benchmarked
 	@printf "$(GREEN)✓ GuideLLM data loaded$(NC)\n"
 
 db-convert-pgdump: db-start ## Convert PostgreSQL dump to JSON format

--- a/docs/design/estimated-performance.md
+++ b/docs/design/estimated-performance.md
@@ -1,0 +1,666 @@
+# Design: Estimated Performance Integration
+
+**Issue**: [#137 — Integration of Config Explorer capabilities into recommendation pipeline](https://github.com/llm-d-incubation/llm-d-planner/issues/137)
+
+**Status**: Phase 1 (Backend Core) and Phase 2 (UI) implemented. Phase 3 (Validation CLI) pending.
+
+**Goal**: When benchmark data is unavailable for a model/GPU combination, generate estimated performance using the Capacity Planner (memory feasibility) and GPU Recommender (BentoML roofline model), and present those estimates alongside benchmark-based recommendations.
+
+---
+
+## 1. Problem Statement
+
+The Planner recommendation pipeline currently relies exclusively on performance benchmarks stored in PostgreSQL. The benchmark database covers a limited matrix of (model, GPU, traffic profile) combinations. When a user requests a model or GPU that lacks benchmark data, the system returns zero results.
+
+Two existing in-process components can fill this gap:
+
+- **Capacity Planner** (`src/planner/capacity_planner.py`) — calculates GPU memory requirements and determines whether a model physically fits on a given GPU at various tensor parallelism (TP) degrees.
+- **GPU Recommender** (`src/planner/gpu_recommender.py`) — uses BentoML's `llm_optimizer` roofline model to estimate TTFT, ITL, E2E latency, and throughput without running actual benchmarks.
+
+---
+
+## 2. Requirements
+
+### Functional Requirements
+
+| ID | Requirement | Details |
+|----|-------------|---------|
+| FR-1 | **Model selection in user intent** | Users can specify one or more models in their natural language description ("I want to deploy Llama 3.3 70B"). The LLM extraction prompt extracts `preferred_models` (analogous to the existing `preferred_gpu_types` extraction in `src/planner/llm/prompts.py`). Users can then review and modify the extracted models via the "Modify Extracted Context" form, which provides both a multi-select from `data/configuration/model_catalog.json` and free-text entry for arbitrary HuggingFace model IDs. |
+| FR-2 | **GPU selection from catalog** | Replace the hardcoded GPU list in `ui/components/extraction.py:165` (`["Any GPU", "H100", "A100", "A10G", "L4", "T4"]`) with a dynamic list from `data/configuration/gpu_catalog.json`. Support multi-select. |
+| FR-3 | **Display constraints in Technical Specification** | Show user-selected GPUs and models in the Technical Specification tab. Display "Any" when no filter is applied, or list specific selections. |
+| FR-4 | **Editable GPU and model lists** | Both GPU and model lists are editable via multi-select widgets in the "Modify Extracted Context" form. |
+| FR-5 | **Estimated performance fallback** | When benchmark data is missing for (model, GPU) combinations, generate estimated performance, store it in `exported_summaries` (with `source='llm-optimizer'`, `confidence_level='estimated'`), and merge results into the recommendation pipeline. On subsequent requests, prior roofline estimates are returned by the existing DB query — the roofline model only runs for genuinely new combinations. |
+| FR-6 | **Visual differentiation** | Recommendation cards display a badge based on `confidence_level`: **"Benchmarked"** (green) for real or validated benchmarks, **"Estimated"** (amber) for roofline model estimates. |
+| FR-7 | **Toggle for estimated recommendations** | Configuration tab includes a toggle to enable/disable estimated recommendations. Default: enabled. |
+| FR-8 | **Configurable scope** | Default: estimated flow triggers only for user-specified models. Configurable: enable for all catalog models without benchmark data. |
+| FR-9 | **Persistence of estimated results** | Estimated results are written to the existing `exported_summaries` table with `source='llm-optimizer'` and `confidence_level='estimated'`. On subsequent requests, the DB query returns them alongside other benchmarks — the roofline model only runs for (model, GPU, traffic profile) combinations not already in the DB. Roofline estimates can be cleared independently via `DELETE WHERE source = 'llm-optimizer'` (API/UI). |
+| FR-10 | **DB source and confidence classification** | Repurpose the existing `source` column (currently `local`/`model_catalog`) to identify the benchmark tool/method: `guidellm`, `blis`, `llm-optimizer`, `manual`, `model_catalog`, `llmd-benchmark`, etc. Add a new `confidence_level` column with 2 values: `benchmarked` (real or validated benchmarks, including physics-based simulation like BLIS), `estimated` (analytical/roofline models). The mapping from source to confidence level is set at data load time. Both columns are free-form text for extensibility. |
+| FR-11 | **Test coverage** | All new and modified functions must have unit tests. Existing functions that are touched by these changes must have tests added if they don't already exist. |
+
+### Non-Functional Requirements
+
+| ID | Requirement | Details |
+|----|-------------|---------|
+| NFR-1 | **Configurable latency budget** | HuggingFace API calls for model config may take 2-5s (cached after first call). Roofline estimation is ~0.5-2s per (model, GPU) pair. The maximum number of models to evaluate and the overall timeout must be configurable (environment variable or config file). Default cap: 5 models, 60s timeout. |
+| NFR-2 | **Graceful degradation with user feedback** | All estimation failures (HF API unreachable, model doesn't exist, roofline failures) must be reported to the user in the response metadata, not just logged. The UI should display warnings for skipped models (e.g., "Could not estimate performance for model X: HuggingFace API unreachable"). |
+| NFR-3 | **Estimated results persistence** | Estimated results are stored in `exported_summaries` (see FR-9). They can be cleared independently via `source` filter (`DELETE WHERE source = 'llm-optimizer'`) from the Configuration tab and API. |
+
+---
+
+## 3. Request Flow
+
+### 3.1 Current Flow
+
+```
+User Input
+  --> LLM Extraction
+  --> DeploymentIntent (use_case, user_count, preferred_gpu_types)
+  --> TrafficProfile + SLOTargets
+  --> ConfigFinder.plan_all_capacities()
+        [1] normalize_gpu_types()
+        [2] find_configurations_meeting_slo() --> PostgreSQL
+        [3] If no results AND GPU filter was from cluster detection:
+            retry without GPU filter
+        [4] If still no results: return []          <-- dead end
+        [5] For each BenchmarkData: build GPUConfig, score, rank
+  --> DeploymentRecommendation[]
+```
+
+### 3.2 Proposed Flow
+
+```
+User Input
+  --> LLM Extraction
+  --> DeploymentIntent (use_case, user_count, preferred_gpu_types,
+                        preferred_models)                          <-- NEW
+  --> TrafficProfile + SLOTargets
+  --> ConfigFinder.plan_all_capacities()
+        [1] normalize_gpu_types()
+        [2] find_configurations_meeting_slo() --> PostgreSQL
+        [3] If no results AND GPU filter was from cluster detection:
+            retry without GPU filter
+        [4] NEW: _generate_estimated_configs()                     <-- NEW
+            [a] Determine which (model, GPU, TP) combos need estimation:
+                - Build set of (model, GPU, TP) triples already in DB results
+                  (includes prior roofline estimates from earlier requests)
+                - User-specified models with uncovered combos
+                - (Optionally) catalog models with uncovered combos
+            [b] Determine GPUs to evaluate:
+                - User-specified GPUs, or all catalog GPUs if none specified
+            [c] For each model:
+                - For each GPU:
+                  - check_model_fits_gpu() --> list of valid TP values
+                  - For each valid TP not already covered:
+                    - GPURecommender.get_gpu_results() --> estimates
+                    - Convert PerformanceEstimationResult --> BenchmarkData
+                - Write new estimates to exported_summaries
+                  (source='llm-optimizer', confidence_level='estimated')
+            [d] Append new estimated configs to matching_configs
+        [5] If no matching_configs (benchmark + estimated): return []
+        [6] For each BenchmarkData: build GPUConfig, score, rank   (unchanged)
+  --> DeploymentRecommendation[]
+```
+
+**Insertion point**: `src/planner/recommendation/config_finder.py`, after line 253 (cluster-GPU fallback), before line 255 (`if not matching_configs: return []`).
+
+The key design principle: estimated results are injected as `BenchmarkData` objects before the scoring loop. The downstream scoring pipeline works unchanged. One change was made to the ranking layer: the Analyzer's ACCURACY-FIRST strategy (which pre-selected top N models by accuracy, then restricted all other cards to only those models) was removed. Each card (Best Accuracy, Lowest Cost, etc.) now sorts independently from all filtered configs. This prevents preferred models from being filtered out when they don't rank in the top N by accuracy.
+
+---
+
+## 4. APIs Between Components
+
+### 4.1 New: `check_model_fits_gpu()`
+
+**Location**: `src/planner/capacity_planner.py`
+
+**Purpose**: Wraps existing building blocks into a single "does it fit?" check.
+
+```python
+def check_model_fits_gpu(
+    model_name: str,
+    model_config: AutoConfig,
+    gpu_memory_gb: int,
+    gpu_util: float = 0.9,
+    hf_token: str | None = None,
+) -> list[int]:
+    """
+    Check which tensor parallelism (TP) values allow the model to fit on the GPU.
+
+    Returns sorted list of valid TP values where allocatable KV cache memory > 0.
+    Empty list means the model does not fit at any TP.
+    """
+```
+
+**Logic**:
+1. Call `find_possible_tp(model_config)` to get architecturally valid TP divisors.
+2. For each TP value, call `allocatable_kv_cache_memory(model_name, model_config, gpu_memory_gb, gpu_util, tp=tp)`.
+3. Return sorted list of TP values where allocatable memory > 0.
+
+**Examples**:
+```
+check_model_fits_gpu("meta-llama/Llama-3.3-70B-Instruct", config, 80)
+  --> [2, 4, 8]     # 70B model needs TP>=2 on 80GB GPU
+
+check_model_fits_gpu("meta-llama/Llama-3.1-8B-Instruct", config, 24)
+  --> [1, 2, 4, 8]  # 8B model fits on 24GB GPU at TP=1
+
+check_model_fits_gpu("meta-llama/Llama-3.3-70B-Instruct", config, 24)
+  --> []             # Too large for L4 at any TP
+```
+
+**Existing functions used** (no changes needed):
+- `find_possible_tp()` (`capacity_planner.py`)
+- `allocatable_kv_cache_memory()` (`capacity_planner.py`)
+- `get_model_config_from_hf()` (`capacity_planner.py`) — called by the orchestrator, not this function
+
+### 4.2 New: `_generate_estimated_configs()`
+
+**Location**: `src/planner/recommendation/config_finder.py` (private method on `ConfigFinder`)
+
+```python
+def _generate_estimated_configs(
+    self,
+    traffic_profile: TrafficProfile,
+    slo_targets: SLOTargets,
+    preferred_models: list[str],
+    existing_benchmarks: list[BenchmarkData],
+    gpu_types: list[str] | None,
+    estimate_all_catalog: bool = False,
+) -> tuple[list[BenchmarkData], list[str]]:
+    """
+    Generate estimated BenchmarkData for (model, GPU) pairs without benchmarks.
+
+    Args:
+        traffic_profile: Current traffic profile (prompt_tokens, output_tokens)
+        slo_targets: SLO targets (TTFT, ITL, E2E)
+        preferred_models: User-specified model IDs (HuggingFace format)
+        existing_benchmarks: Benchmark results already found from DB
+        gpu_types: GPU types to evaluate (None = all catalog GPUs)
+        estimate_all_catalog: If True, also estimate for catalog models
+                             without benchmarks (not just user-specified)
+
+    Returns:
+        Tuple of (list of BenchmarkData with estimated=True, list of warning strings)
+    """
+```
+
+**Orchestration logic**:
+
+1. Build the set of (model, GPU) pairs already covered by `existing_benchmarks` returned from the DB query. This includes any prior roofline estimates that were stored on earlier requests — they are already in `exported_summaries` and returned by `find_configurations_meeting_slo()`.
+2. Determine models to estimate:
+   - Always include `preferred_models` whose (model, GPU) pairs are not fully covered.
+   - If `estimate_all_catalog`: also include catalog models with uncovered pairs.
+3. Determine GPUs to evaluate:
+   - If `gpu_types` is provided: use those.
+   - Otherwise: use all GPUs from `gpu_catalog.json` via `self.catalog.get_all_gpu_types()`.
+4. For each model:
+   - Fetch model config via `get_model_config_from_hf()` (cached).
+   - For each GPU:
+     - Call `check_model_fits_gpu()` — get valid TP values.
+     - If no valid TP: skip.
+     - For each valid TP value:
+       - Skip if (model, GPU, TP) already in covered set (from step 1).
+       - Call `GPURecommender` with this model, GPU, TP, traffic profile, and SLO constraints.
+       - Convert results to `BenchmarkData` with `source='llm-optimizer'`, `confidence_level='estimated'`.
+     - Write all new estimates to `exported_summaries` so future requests get a DB hit.
+5. Return list of newly estimated `BenchmarkData` objects (appended to `matching_configs`).
+
+### 4.3 Existing: `GPURecommender` (modified)
+
+**Location**: `src/planner/gpu_recommender.py`
+
+The existing `GPURecommender` class provides the core estimation logic. One fix was required: the constraint string passed to `llm_optimizer` was concatenating parts without delimiters. The `llm_optimizer` library expects semicolon-separated constraints (`split(";")`), so constraint building was changed to use `";".join(constraint_parts)`.
+
+```python
+recommender = GPURecommender(
+    model_id="meta-llama/Llama-3.3-70B-Instruct",
+    input_len=512,                    # From traffic_profile.prompt_tokens
+    output_len=256,                   # From traffic_profile.output_tokens
+    max_gpus=tp,                      # Each valid TP from check_model_fits_gpu()
+    gpu_list=["H100"],                # Single GPU for this evaluation
+    max_ttft=slo_targets.ttft_p95,    # SLO constraint
+    max_itl=slo_targets.itl_p95,      # SLO constraint
+    max_latency=slo_targets.e2e_p95 / 1000,  # SLO constraint (ms -> s)
+)
+gpu_results, failed_gpus = recommender.get_gpu_results()
+```
+
+**Output**: `dict[str, PerformanceEstimationResult]` keyed by GPU name.
+
+Each `PerformanceEstimationResult.best_configs` is a dict with entries like `best_latency` containing:
+- `ttft_ms` (float)
+- `itl_ms` (float)
+- `e2e_latency_s` (float)
+- `output_throughput_tps` (float)
+
+The constraint delimiter fix and GPU name mapping were the only changes needed.
+
+### 4.4 New: `_convert_estimation_to_benchmark()`
+
+**Location**: `src/planner/recommendation/config_finder.py` (static method on `ConfigFinder`)
+
+```python
+@staticmethod
+def _convert_estimation_to_benchmark(
+    model_id: str,
+    gpu_type: str,
+    gpu_count: int,
+    prompt_tokens: int,
+    output_tokens: int,
+    ttft_ms: float,
+    itl_ms: float,
+    e2e_latency_ms: float,
+    output_throughput_tps: float,
+) -> BenchmarkData:
+    """
+    Convert GPU Recommender output to BenchmarkData format.
+
+    The roofline model produces single-point estimates (no percentile
+    distribution), so the same value is used for mean/p90/p95/p99.
+    """
+```
+
+**Field mapping**:
+
+| Source | BenchmarkData field(s) |
+|--------|----------------------|
+| `ttft_ms` | `ttft_mean`, `ttft_p90`, `ttft_p95`, `ttft_p99` (all same value) |
+| `itl_ms` | `itl_mean`, `itl_p90`, `itl_p95`, `itl_p99` (all same value) |
+| `e2e_latency_s * 1000` | `e2e_mean`, `e2e_p90`, `e2e_p95`, `e2e_p99` (all same, in ms) |
+| `output_throughput_tps` | `tps_mean`, `tps_p90`, `tps_p95`, `tps_p99`, `tokens_per_second` |
+| `output_throughput_tps / output_tokens` | `requests_per_second` |
+| `model_id` | `model_hf_repo` |
+| `gpu_type` | `hardware` |
+| `gpu_count` | `hardware_count` |
+| `prompt_tokens` | `prompt_tokens`, `mean_input_tokens` |
+| `output_tokens` | `output_tokens`, `mean_output_tokens` |
+| `"vllm"` | `framework` |
+| `"estimated"` | `framework_version` |
+| `True` | `estimated` |
+| `"llm-optimizer"` | `source` |
+| `"estimated"` | `confidence_level` |
+
+### 4.5 Modified: `DeploymentIntent` Schema
+
+**Location**: `src/planner/shared/schemas/intent.py`
+
+Add field:
+```python
+preferred_models: list[str] = Field(
+    default_factory=list,
+    description="List of user's preferred model IDs (HuggingFace format, empty = any model). "
+    "Can be catalog model_ids or arbitrary HF repo IDs.",
+)
+```
+
+### 4.6 Modified: `plan_all_capacities()` Signature and Return Type
+
+**Location**: `src/planner/recommendation/config_finder.py`
+
+Add parameters:
+```python
+preferred_models: list[str] | None = None,
+enable_estimated: bool = True,
+```
+
+**Return type changed** from `list[DeploymentRecommendation]` to `tuple[list[DeploymentRecommendation], list[str]]`. The second element contains estimation warnings (e.g., "Model X does not fit on any available GPU", "Estimation skipped for model X on GPU Y: ..."). All callers in `workflow.py` unpack this tuple and thread warnings through to `RankedRecommendationsResponse.warnings`.
+
+**Preferred model filtering**: When `preferred_models` is specified, the final `matching_configs` list is filtered to only include configurations for those models. If no preferred models produced viable configs, all configs are returned as a fallback.
+
+**Exception handling for `check_model_fits_gpu()`**: Some model architectures (e.g., GGUF repos) cause `NotASafetensorsRepoError` when `check_model_fits_gpu()` calls `get_safetensors_metadata()`. These exceptions are caught and the model is skipped with a warning.
+
+### 4.7 Modified: `BenchmarkData`
+
+**Location**: `src/planner/knowledge_base/benchmarks.py`
+
+Add `source` and `confidence_level` fields to `__init__()` and `to_dict()`. See section 8.3 for details.
+
+### 4.8 Modified: API Route
+
+**Location**: `src/planner/api/routes/recommendation.py`
+
+Add to `RankedRecommendationFromSpecRequest`:
+```python
+preferred_models: list[str] | None = None
+enable_estimated: bool = True
+```
+
+Pass through to `plan_all_capacities()`.
+
+---
+
+## 5. UI Changes
+
+### 5.1 Define Use Case Tab — Model Selection
+
+**Location**: `ui/app.py` and `ui/components/extraction.py`
+
+Add model selection after LLM extraction produces the initial intent:
+- `st.multiselect` populated from model catalog IDs.
+- `st.text_input` for free-text HuggingFace model IDs (comma-separated).
+- Store in `st.session_state.preferred_models`.
+
+### 5.2 Define Use Case Tab — GPU Selection Fix
+
+**Location**: `ui/components/extraction.py`, `render_extraction_edit_form()`, line 165
+
+Replace hardcoded list with dynamic loading via `fetch_gpu_types()` API client. Change from `st.selectbox` (single) to `st.multiselect` (multi).
+
+### 5.3 Technical Specification Tab — Display Constraints
+
+**Location**: `ui/components/slo.py`
+
+Add a section showing:
+- "GPUs: Any" or "GPUs: H100, A100-80"
+- "Models: Any" or "Models: meta-llama/Llama-3.3-70B-Instruct, Qwen/Qwen3-32B"
+
+### 5.4 Modify Extracted Context — Multi-select for Both
+
+**Location**: `ui/components/extraction.py`, `render_extraction_edit_form()`
+
+Replace single GPU selectbox with multi-select. Add model multi-select + free-text input.
+
+### 5.5 Recommendation Cards — Confidence Badges
+
+**Location**: `ui/components/recommendations.py`
+
+Check `rec.get("benchmark_metrics", {}).get("confidence_level", "benchmarked")`:
+- `"benchmarked"`: Green **"Benchmarked"** badge — tooltip: "Based on real hardware benchmark data."
+- `"estimated"`: Amber **"Estimated"** badge — tooltip: "Based on roofline model estimation. Actual performance may vary."
+
+### 5.6 Configuration Tab — Estimated Toggle
+
+**Location**: `ui/components/settings.py`
+
+Add toggle:
+```python
+st.subheader("Estimated Performance")
+enable_estimated = st.toggle(
+    "Enable estimated performance for models without benchmarks",
+    value=True,
+    key="enable_estimated",
+)
+```
+
+---
+
+## 6. Error Handling
+
+All estimation failures are collected and returned in the API response metadata so the UI can display warnings to the user. This applies consistently to all failure scenarios — the user always knows what was skipped and why.
+
+| Scenario | Handling |
+|----------|----------|
+| HuggingFace API unreachable | Skip model, collect in response `warnings` list for UI display (e.g., "Could not estimate performance for model X: HuggingFace API unreachable"), continue with remaining models |
+| Model ID doesn't exist on HF | Skip, collect in response `warnings` list for UI display (e.g., "Model 'meta-llama/llama-3.3-70b-instuct' not found on HuggingFace") |
+| Roofline estimation fails for (model, GPU) | Already handled by `GPURecommender.get_gpu_results()` — stored in `failed_gpus` dict; propagate to response `warnings` |
+| Model fits no GPUs | Skip model entirely, add to `warnings` (e.g., "Model X does not fit on any available GPU") |
+| No benchmarks AND no estimated results | Return empty list (existing behavior); enhance error message to mention estimation was attempted |
+| Latency budget exceeded | Configurable cap on models evaluated (default 5) and overall timeout (default 60s). Use `check_model_fits_gpu()` as fast pre-filter before slower roofline model. Consider `ThreadPoolExecutor` for parallelization. |
+
+---
+
+## 7. Session State and Configuration
+
+### New Session State Keys
+
+Add to `ui/state.py` `SESSION_DEFAULTS`:
+```python
+"preferred_models": [],
+"enable_estimated": True,
+```
+
+### API Request Payload Changes
+
+`fetch_ranked_recommendations()` in `ui/api_client.py` must include:
+```python
+"preferred_models": preferred_models or [],
+"enable_estimated": enable_estimated,
+```
+
+### Backend Configuration
+
+The `estimate_all_catalog` setting (FR-8) is a backend configuration (environment variable or config file), not exposed in the UI initially.
+
+Configurable latency budget settings (environment variables):
+```
+PLANNER_ESTIMATED_MAX_MODELS=5        # Max models to evaluate in estimated flow
+PLANNER_ESTIMATED_TIMEOUT_S=60        # Overall timeout for estimated flow
+```
+
+---
+
+## 8. Database Schema Changes
+
+All benchmark data lives in the single `exported_summaries` table. No separate cache table is needed — roofline estimates are written to the same table and returned by the existing `find_configurations_meeting_slo()` query on subsequent requests. They can be selectively cleared via `DELETE WHERE source = 'llm-optimizer'`.
+
+### 8.1 Repurpose `source` Column
+
+The `source` column already exists as `text NOT NULL DEFAULT 'local'`. Current values are `local` (CLI-loaded data) and `model_catalog` (catalog sync). Repurpose it to identify the benchmark tool/method:
+
+| `source` value | Meaning | Loaded by |
+|----------------|---------|-----------|
+| `guidellm` | Real hardware benchmarks from GuideLLM | `make db-load-guidellm` |
+| `blis` | BLIS physics-based simulator | `make db-load-blis` |
+| `llm-optimizer` | BentoML llm-optimizer roofline estimates | Estimated flow (runtime) |
+| `manual` | Manually produced data (estimated or interpolated) | `make db-load-estimated`, `make db-load-interpolated` |
+| `model_catalog` | Model catalog sync | `model_catalog_sync.py` (unchanged) |
+| `llmd-benchmark` | llm-d benchmark tool (future) | Future loader |
+| `other` | Unclassified / legacy | Default for migration |
+
+**Migration**: Update existing data:
+```sql
+-- Migrate existing source values to new semantics
+-- Existing 'local' data needs manual classification or a default
+UPDATE exported_summaries SET source = 'other' WHERE source = 'local';
+```
+
+Note: The `model_catalog_sync.py` deletion logic (`DELETE WHERE source = 'model_catalog'`) continues to work unchanged. The roofline cleanup (`DELETE WHERE source = 'llm-optimizer'`) follows the same pattern.
+
+**Update `loader.py`**: Accept `source` as a parameter instead of hardcoding `"local"`. The Makefile targets pass the appropriate value:
+```
+make db-load-blis       -->  source='blis'
+make db-load-estimated  -->  source='manual'
+make db-load-guidellm   -->  source='guidellm'
+```
+
+### 8.2 Add `confidence_level` Column
+
+```sql
+ALTER TABLE exported_summaries
+    ADD COLUMN IF NOT EXISTS confidence_level text NOT NULL DEFAULT 'estimated';
+
+COMMENT ON COLUMN exported_summaries.confidence_level IS
+    'Trust level: benchmarked (real or validated benchmarks), estimated (analytical/llm-optimizer)';
+```
+
+| `confidence_level` | Meaning | UI Badge | Sources |
+|--------------------|---------|----------|---------|
+| `benchmarked` | Real or validated benchmarks | Green "Benchmarked" | `guidellm`, `llmd-benchmark`, `blis` |
+| `estimated` | Analytical / roofline model | Amber "Estimated" | `llm-optimizer`, `manual` |
+
+The mapping from `source` to `confidence_level` is set at load time by the loader or the estimated flow. It is not derived automatically.
+
+### 8.3 Update `BenchmarkData` Class
+
+**Location**: `src/planner/knowledge_base/benchmarks.py`
+
+Add fields to `BenchmarkData.__init__()`:
+```python
+self.source = data.get("source", "other")
+self.confidence_level = data.get("confidence_level", "estimated")
+```
+
+Add to `to_dict()`:
+```python
+"estimated": self.estimated,
+"source": self.source,
+"confidence_level": self.confidence_level,
+```
+
+Update `find_configurations_meeting_slo()` to include `source` and `confidence_level` in the SELECT columns.
+
+### 8.4 Clearing Estimated Data
+
+- **API endpoint**: `DELETE /api/v1/benchmarks/llm-optimizer` — runs `DELETE FROM exported_summaries WHERE source = 'llm-optimizer'`
+- **UI**: "Clear Estimated Data" button in Configuration tab
+- **CLI**: `make db-clear-estimated`
+- **Optional TTL-based cleanup** (future): `DELETE WHERE source = 'llm-optimizer' AND created_at < NOW() - INTERVAL '7 days'`
+
+---
+
+## 9. LLM Extraction — Model Name Extraction
+
+### 9.1 Extraction Prompt Update
+
+**Location**: `src/planner/llm/prompts.py`
+
+Add `preferred_models` to the extraction schema (follows the same pattern as `preferred_gpu_types`):
+
+```json
+"preferred_models": ["<list of model IDs if mentioned, empty list if not specified>"]
+```
+
+Add extraction examples to the prompt:
+```
+Model extraction examples (use HuggingFace format):
+- "deploy Llama 3.3 70B" → preferred_models: ["meta-llama/Llama-3.3-70B-Instruct"]
+- "I want to use Qwen3-32B or Mistral Small" → preferred_models: ["Qwen/Qwen3-32B", "mistralai/Mistral-Small-24B-Instruct-2501"]
+- "compare granite and llama for my use case" → preferred_models: ["ibm-granite/granite-3.1-8b-instruct", "meta-llama/Llama-3.1-8B-Instruct"]
+- No model mentioned → preferred_models: []
+```
+
+The LLM should map common model names to their canonical HuggingFace repo IDs. The model catalog (`data/configuration/model_catalog.json`) provides the mapping — include a representative subset in the prompt for reference.
+
+### 9.2 User Modification Flow
+
+After LLM extraction, the user reviews the extracted `preferred_models` in the approval view. They can:
+1. Accept the extracted models as-is.
+2. Click "Modify Extracted Context" to adjust:
+   - Multi-select from model catalog (pre-populated with catalog `model_id` values).
+   - Free-text input for arbitrary HuggingFace model IDs not in the catalog.
+
+---
+
+## 10. Test Requirements (FR-11)
+
+### 11.1 New Unit Tests Required
+
+| Function | Test File | Test Cases |
+|----------|-----------|------------|
+| `check_model_fits_gpu()` | `tests/unit/test_capacity_planner.py` | Model fits at TP=1; model needs TP=2+; model too large for any TP; edge cases (0 memory, invalid config) |
+| `_generate_estimated_configs()` | `tests/unit/test_config_finder.py` | No models to estimate; models partially covered by benchmarks; all models uncovered; GPU filter applied; HF API failure (mocked); roofline failure (mocked) |
+| `_convert_estimation_to_benchmark()` | `tests/unit/test_config_finder.py` | Correct field mapping; all percentiles set to same value; E2E unit conversion (s→ms); requests_per_second calculation |
+| Validation CLI | `tests/unit/test_validate_estimation.py` | Comparison logic; MAPE calculation; CSV output format (future work) |
+
+### 11.2 Existing Functions — Verify Coverage
+
+| Function | Test File | Status |
+|----------|-----------|--------|
+| `BenchmarkData.to_dict()` | `tests/unit/test_benchmarks.py` | Verify `estimated`, `source`, `confidence_level` fields are included |
+| `DeploymentIntent` with `preferred_models` | `tests/unit/test_schemas.py` | Verify new field serialization/deserialization |
+| `plan_all_capacities()` | `tests/unit/test_config_finder.py` | Add cases for `enable_estimated=True/False`, `preferred_models` parameter |
+| LLM extraction prompt | `tests/unit/test_extraction.py` | Add cases verifying `preferred_models` extraction from natural language |
+
+### 11.3 Integration Tests
+
+| Scenario | Description |
+|----------|-------------|
+| End-to-end estimated flow | User specifies a model not in DB → estimated results returned with `estimated=True` |
+| Mixed benchmark + estimated | Some (model, GPU) combos have benchmarks, others estimated → both appear in results |
+| Estimated toggle disabled | `enable_estimated=False` → only benchmark results, no estimation attempted |
+| DB cache hit | Second request for same (model, GPU, traffic) → prior roofline estimate returned from `exported_summaries`, no re-computation |
+
+---
+
+## 11. Implementation Sequence
+
+### Phase 1: Backend Core
+1. DB schema: repurpose `source` column, add `confidence_level` column to `exported_summaries`
+2. Add `check_model_fits_gpu()` to `capacity_planner.py`
+3. Add `preferred_models` to `DeploymentIntent`
+4. Update LLM extraction prompt for model name extraction
+5. Add `_generate_estimated_configs()` and `_convert_estimation_to_benchmark()` to `ConfigFinder`
+6. Modify `plan_all_capacities()` to call estimated flow
+7. Add `enable_estimated` parameter through API route chain
+8. Add `source`, `confidence_level` to `BenchmarkData`
+9. Write roofline estimates to `exported_summaries`; update `loader.py` to accept `source`/`confidence_level`
+10. Add response `warnings` field for estimation failures
+11. Unit tests for all new/modified functions
+
+### Phase 2: UI Changes
+1. Replace hardcoded GPU list with catalog-driven multi-select
+2. Add model selection widgets (multi-select + free text)
+3. Add estimated toggle, "Clear Estimated Data" button to Configuration tab
+4. Pass new parameters through API client
+5. Add "Benchmarked" and "Estimated" badges to recommendation cards
+6. Show GPU/model constraints in Technical Specification tab
+7. Display estimation warnings to user
+
+### Phase 3: Validation and Polish (future — not part of this PR)
+1. Build estimation accuracy validation CLI tool (see section 13.1)
+2. Run initial accuracy baseline against existing benchmark data
+3. Add `estimate_all_catalog` configuration option
+4. Performance optimization (parallelization, configurable timeouts)
+5. Confidence scoring based on validation results (see section 13.2)
+6. "Clear Estimated Data" button in Configuration tab
+
+---
+
+## 12. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Roofline estimates diverge significantly from real benchmarks | Clear "Estimated"/"Benchmarked" labeling; accuracy validation tool (future); confidence discount in scoring based on measured MAPE |
+| HuggingFace rate limiting on model config fetches | `@lru_cache` already in place; roofline estimates persisted in DB; add retry with backoff |
+| Response time increase for large matrices | Configurable cap on models/timeout (NFR-1); fast pre-filter via memory check; DB-persisted estimates avoid re-computation; consider `ThreadPoolExecutor` |
+| Free-text model IDs with typos | Validate model exists on HF before estimation; report all failures to UI via `warnings` in response |
+| LLM extraction maps model names incorrectly | Provide reference model list in extraction prompt; user can correct via "Modify Extracted Context" |
+| Roofline estimate staleness | Estimates persisted in DB by `source='llm-optimizer'`; clearable via API/UI/CLI; optional TTL-based cleanup for future |
+
+---
+
+## 13. Future Work
+
+### 13.1 Estimation Accuracy Validation
+
+Provide a CLI tool to measure how well roofline estimates match real benchmark data:
+- Compare estimated vs actual for TTFT, ITL, E2E, throughput across all benchmarked (model, GPU) combinations.
+- Report MAPE, median error, max error, and systematic bias per metric.
+- Location: `scripts/validate_estimation_accuracy.py` (or Makefile target `make validate-estimates`).
+- Also consider exposing validation results in the UI.
+
+### 13.2 Confidence Scoring
+
+Use validation MAPE data to discount estimated scores (e.g., if MAPE for latency is 20%, apply a 20% penalty to the latency score for estimated configs). This would be a multiplier in `src/planner/recommendation/scorer.py`.
+
+### 13.3 Other
+
+- "Clear Estimated Data" button in Configuration tab (FR-9/8.4)
+- `estimate_all_catalog` configuration option
+- Performance optimization (parallelization, configurable timeouts)
+- Integration tests for the estimated performance flow
+- Pluggable estimation backend: abstract the estimation engine behind a common interface so different backends (llm-optimizer, BLIS, etc.) can be swapped without modifying orchestration logic
+
+---
+
+## Appendix A: Key Files
+
+| File | Role |
+|------|------|
+| `src/planner/recommendation/config_finder.py` | Main insertion point (line 255) |
+| `src/planner/capacity_planner.py` | Memory feasibility check (new wrapper function) |
+| `src/planner/gpu_recommender.py` | Roofline estimation (used as-is) |
+| `src/planner/knowledge_base/benchmarks.py` | `BenchmarkData` class |
+| `src/planner/shared/schemas/intent.py` | `DeploymentIntent` schema |
+| `src/planner/api/routes/recommendation.py` | API route for recommendations |
+| `ui/components/extraction.py` | GPU/model selection UI |
+| `ui/components/settings.py` | Estimated toggle |
+| `ui/components/recommendations.py` | Estimated badge |
+| `ui/api_client.py` | API client functions |
+| `data/configuration/gpu_catalog.json` | GPU catalog (12 GPU types) |
+| `data/configuration/model_catalog.json` | Model catalog (45+ models) |
+| `src/planner/llm/prompts.py` | LLM extraction prompt (add `preferred_models`) |
+| `scripts/schema.sql` | DB schema (add `confidence_level` column, update `source` values) |
+| `src/planner/knowledge_base/loader.py` | Benchmark loader (accept `source`/`confidence_level` params) |
+| `scripts/validate_estimation_accuracy.py` | Accuracy validation CLI tool (future — not yet implemented) |
+

--- a/scripts/load_benchmarks.py
+++ b/scripts/load_benchmarks.py
@@ -9,6 +9,7 @@ Core loading logic lives in planner.knowledge_base.loader and is
 shared with the /api/v1/db/* API endpoints.
 """
 
+import argparse
 import json
 import os
 import sys
@@ -65,7 +66,17 @@ def load_benchmarks_json(json_file=None):
 def main():
     """Main function."""
     # Parse command-line arguments
-    json_file = sys.argv[1] if len(sys.argv) > 1 else None
+    parser = argparse.ArgumentParser(description="Load benchmark data into PostgreSQL")
+    parser.add_argument("json_file", nargs="?", default=None, help="Path to benchmark JSON file")
+    parser.add_argument(
+        "--source", default="local", help="Data source identifier (default: local)"
+    )
+    parser.add_argument(
+        "--confidence-level",
+        default="estimated",
+        help="Confidence level for the data (default: estimated)",
+    )
+    args = parser.parse_args()
 
     print("=" * 60)
     print("Loading Benchmark Data into PostgreSQL")
@@ -73,7 +84,7 @@ def main():
     print()
 
     # Load benchmarks from JSON
-    benchmarks = load_benchmarks_json(json_file)
+    benchmarks = load_benchmarks_json(args.json_file)
     print(f"Loaded {len(benchmarks)} benchmarks from JSON")
 
     # Connect to database
@@ -84,7 +95,9 @@ def main():
 
     try:
         # Insert benchmarks using shared loader
-        stats = insert_benchmarks(conn, benchmarks)
+        stats = insert_benchmarks(
+            conn, benchmarks, source=args.source, confidence_level=args.confidence_level
+        )
 
         print("\nDatabase Statistics:")
         print(f"  Models: {stats['num_models']}")

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -59,6 +59,8 @@ CREATE TABLE IF NOT EXISTS exported_summaries (
 -- Idempotent migrations for existing databases
 ALTER TABLE exported_summaries ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'local';
 ALTER TABLE exported_summaries ADD COLUMN IF NOT EXISTS model_uri text;
+ALTER TABLE exported_summaries ADD COLUMN IF NOT EXISTS confidence_level text NOT NULL DEFAULT 'estimated';
+COMMENT ON COLUMN exported_summaries.confidence_level IS 'Trust level: benchmarked (real or validated benchmarks), estimated (analytical/roofline models)';
 
 -- Unique constraint on config_id (required for ON CONFLICT in upsert queries)
 CREATE UNIQUE INDEX IF NOT EXISTS idx_config_id_unique ON exported_summaries (config_id);

--- a/src/planner/api/app.py
+++ b/src/planner/api/app.py
@@ -28,6 +28,9 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
+# Suppress noisy HTTP request logs from huggingface_hub / httpx
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 

--- a/src/planner/api/dependencies.py
+++ b/src/planner/api/dependencies.py
@@ -129,7 +129,10 @@ def init_app_state(app: FastAPI) -> None:
     else:
         app.state.model_catalog_client = None
         app.state.model_catalog_sync_thread = None
-        app.state.workflow = RecommendationWorkflow()
+        from planner.recommendation.config_finder import ConfigFinder
+
+        config_finder = ConfigFinder(catalog=app.state.model_catalog)
+        app.state.workflow = RecommendationWorkflow(config_finder=config_finder)
         logger.info("Using PostgreSQL as benchmark source")
 
 

--- a/src/planner/api/routes/recommendation.py
+++ b/src/planner/api/routes/recommendation.py
@@ -68,7 +68,7 @@ class RankedRecommendationFromSpecRequest(BaseModel):
 
 
 @router.post("/recommend")
-async def simple_recommend(
+def simple_recommend(
     request: SimpleRecommendationRequest,
     workflow: RecommendationWorkflow = Depends(get_workflow),
     deployment_generator: DeploymentGenerator = Depends(get_deployment_generator),
@@ -160,7 +160,7 @@ async def simple_recommend(
 
 
 @router.post("/ranked-recommend-from-spec")
-async def ranked_recommend_from_spec(
+def ranked_recommend_from_spec(
     request: RankedRecommendationFromSpecRequest,
     workflow: RecommendationWorkflow = Depends(get_workflow),
 ):

--- a/src/planner/api/routes/recommendation.py
+++ b/src/planner/api/routes/recommendation.py
@@ -54,6 +54,12 @@ class RankedRecommendationFromSpecRequest(BaseModel):
     e2e_target_ms: int
     percentile: Literal["mean", "p90", "p95", "p99"] = "p95"
 
+    # Model preferences
+    preferred_models: list[str] | None = None  # User-specified HF model IDs
+
+    # Estimated performance
+    enable_estimated: bool = True  # Run roofline estimation for missing benchmarks
+
     # Ranking options
     min_accuracy: int | None = None
     max_cost: float | None = None
@@ -186,6 +192,7 @@ async def ranked_recommend_from_spec(
         logger.info(f"  use_case: {request.use_case}")
         logger.info(f"  user_count: {request.user_count}")
         logger.info(f"  preferred_gpu_types: {request.preferred_gpu_types}")
+        logger.info(f"  preferred_models: {request.preferred_models}")
         logger.info(f"  prompt_tokens: {request.prompt_tokens}")
         logger.info(f"  output_tokens: {request.output_tokens}")
         logger.info(f"  expected_qps: {request.expected_qps}")
@@ -196,6 +203,7 @@ async def ranked_recommend_from_spec(
         logger.info(f"  min_accuracy: {request.min_accuracy}")
         logger.info(f"  max_cost: {request.max_cost}")
         logger.info(f"  include_near_miss: {request.include_near_miss}")
+        logger.info(f"  enable_estimated: {request.enable_estimated}")
         if request.weights:
             logger.info(
                 f"  weights: accuracy={request.weights.accuracy}, price={request.weights.price}, "
@@ -212,6 +220,7 @@ async def ranked_recommend_from_spec(
                 "user_count": request.user_count,
                 "domain_specialization": ["general"],
                 "preferred_gpu_types": request.preferred_gpu_types or [],
+                "preferred_models": request.preferred_models or [],
             },
             "traffic_profile": {
                 "prompt_tokens": request.prompt_tokens,
@@ -243,6 +252,7 @@ async def ranked_recommend_from_spec(
             max_cost=request.max_cost,
             include_near_miss=request.include_near_miss,
             weights=weights_dict,
+            enable_estimated=request.enable_estimated,
         )
 
         logger.info(

--- a/src/planner/capacity_planner.py
+++ b/src/planner/capacity_planner.py
@@ -215,18 +215,24 @@ class KVCacheDetail:
 
 
 # Model
+
+
+@lru_cache(maxsize=128)
 def get_model_info_from_hf(model_name: str, hf_token: str | None = None) -> ModelInfo:
     """
-    Fetches model info from HF, does not handle error
+    Fetches model info from HF, does not handle error.
+    Results are cached to avoid repeated API calls for the same model.
     """
     api = HfApi(token=hf_token)
     model_info = api.model_info(model_name)
     return model_info
 
 
+@lru_cache(maxsize=128)
 def get_model_config_from_hf(model_name: str, hf_token: str | None = None) -> Any:
     """
-    Returns LLM model config
+    Returns LLM model config.
+    Results are cached to avoid repeated API calls for the same model.
     """
 
     model_config = AutoConfig.from_pretrained(
@@ -907,6 +913,46 @@ def allocatable_kv_cache_memory(
     total_consumed = model_size + activation_memory + cuda_graph_memory + non_torch_memory
 
     return max(0, available_memory - total_consumed)
+
+
+def check_model_fits_gpu(
+    model_name: str,
+    model_config: AutoConfig,
+    gpu_memory_gb: int,
+    gpu_util: float = 0.9,
+    hf_token: str | None = None,
+) -> list[int]:
+    """
+    Check which tensor parallelism (TP) values allow the model to fit on the GPU.
+
+    Iterates through architecturally valid TP values and checks whether the
+    model leaves positive allocatable KV cache memory at each TP degree.
+
+    Args:
+        model_name: HuggingFace model ID
+        model_config: Model configuration from AutoConfig
+        gpu_memory_gb: GPU memory in GB (from gpu_catalog.json memory_gb field)
+        gpu_util: GPU memory utilization factor (default 0.9)
+        hf_token: Optional HuggingFace token for gated models
+
+    Returns:
+        Sorted list of valid TP values where the model fits (allocatable
+        KV cache memory > 0). Empty list means the model does not fit
+        on this GPU at any TP.
+    """
+    valid_tps = []
+    for tp in find_possible_tp(model_config):
+        available = allocatable_kv_cache_memory(
+            model_name,
+            model_config,
+            gpu_memory_gb,
+            gpu_util,
+            tp=tp,
+            hf_token=hf_token,
+        )
+        if available > 0:
+            valid_tps.append(tp)
+    return valid_tps
 
 
 def auto_max_model_len(

--- a/src/planner/gpu_recommender.py
+++ b/src/planner/gpu_recommender.py
@@ -30,6 +30,12 @@ class CostManager:
         custom_costs: dict[str, float] | None = None,
         catalog: ModelCatalog | None = None,
     ):
+        """Initialize cost manager.
+
+        Args:
+            custom_costs: Optional GPU name → cost/hour overrides.
+            catalog: Optional ModelCatalog instance; creates one if not provided.
+        """
         self._catalog = catalog if catalog is not None else ModelCatalog()
         if custom_costs:
             for gpu_name, cost in custom_costs.items():
@@ -94,6 +100,7 @@ class GPURecommender:
         max_latency: float | None = None,
         # Cost parameters
         custom_gpu_costs: dict[str, float] | None = None,
+        catalog: ModelCatalog | None = None,
     ):
         """
         Initialize GPU Recommender.
@@ -111,6 +118,7 @@ class GPURecommender:
             max_itl: Maximum inter-token latency constraint (ms)
             max_latency: Maximum end-to-end latency constraint (s)
             custom_gpu_costs: Optional dict mapping GPU names to custom costs
+            catalog: Optional ModelCatalog instance (avoids reloading JSON files)
         """
 
         # Read HF Token from environment variable
@@ -133,15 +141,22 @@ class GPURecommender:
         self.max_latency = max_latency
 
         # Initialize cost manager
-        self.cost_manager = CostManager(custom_costs=custom_gpu_costs)
+        self.cost_manager = CostManager(custom_costs=custom_gpu_costs, catalog=catalog)
 
         # Store results after recommendation
         self.gpu_results: dict[str, PerformanceEstimationResult] = {}
         self.failed_gpus: dict[str, str] = {}
 
     def get_gpu_results(self) -> tuple[dict[str, PerformanceEstimationResult], dict[str, str]]:
-        """
-        Runs bento's recommendation engine
+        """Run BentoML roofline estimation for each GPU in gpu_list.
+
+        Builds SLO constraints from max_ttft/max_itl/max_latency, then
+        calls llm_optimizer's run_performance_estimation per GPU. Uses
+        GPU-specific max_gpus from max_gpus_per_type when available.
+
+        Returns:
+            Tuple of (gpu_results dict keyed by GPU name,
+                      failed_gpus dict keyed by GPU name with error messages).
         """
 
         gpu_results = {}
@@ -152,13 +167,14 @@ class GPURecommender:
             # Use GPU-specific max_gpus if configured, otherwise use default
             num_gpus = self.max_gpus_per_type.get(gpu_name, self.max_gpus)
 
-            constraints = ""
+            constraint_parts = []
             if self.max_ttft is not None:
-                constraints += f"ttft:p95<={self.max_ttft}ms"
+                constraint_parts.append(f"ttft:p95<={self.max_ttft}ms")
             if self.max_itl is not None:
-                constraints += f"itl:p95<={self.max_itl}ms"
+                constraint_parts.append(f"itl:p95<={self.max_itl}ms")
             if self.max_latency is not None:
-                constraints += f"e2e_latency:p95<={self.max_latency}s"
+                constraint_parts.append(f"e2e_latency:p95<={self.max_latency}s")
+            constraints = ";".join(constraint_parts)
 
             params = PerformanceEstimationParams(
                 model=self.model_id,

--- a/src/planner/knowledge_base/benchmarks.py
+++ b/src/planner/knowledge_base/benchmarks.py
@@ -34,7 +34,13 @@ class BenchmarkData:
     """Model performance benchmark entry."""
 
     def __init__(self, data: dict):
-        """Initialize from database row dict."""
+        """Initialize from a database row or dict with benchmark fields.
+
+        Key fields beyond latency/throughput metrics:
+            estimated: True for roofline-estimated benchmarks (default False).
+            source: Benchmark tool/method, e.g. 'blis', 'llm-optimizer' (default 'other').
+            confidence_level: 'benchmarked' or 'estimated' (default 'estimated').
+        """
         self.model_hf_repo = data["model_hf_repo"]
         self.hardware = data["hardware"]
         self.hardware_count = data["hardware_count"]
@@ -81,6 +87,9 @@ class BenchmarkData:
         # Model artifact URI (e.g., OCI registry URI)
         self.model_uri = data.get("model_uri")
 
+        self.source = data.get("source", "other")
+        self.confidence_level = data.get("confidence_level", "estimated")
+
     def to_dict(self) -> dict:
         """Convert to dictionary."""
         return {
@@ -112,6 +121,9 @@ class BenchmarkData:
             "tokens_per_second": self.tokens_per_second,
             "requests_per_second": self.requests_per_second,
             "model_uri": self.model_uri,
+            "estimated": self.estimated,
+            "source": self.source,
+            "confidence_level": self.confidence_level,
         }
 
 
@@ -144,6 +156,36 @@ class BenchmarkRepository:
     def _get_connection(self):
         """Get a database connection."""
         return psycopg2.connect(self.database_url, cursor_factory=RealDictCursor)
+
+    def save_benchmarks(
+        self,
+        benchmarks: list["BenchmarkData"],
+        source: str = "llm-optimizer",
+        confidence_level: str = "estimated",
+    ) -> None:
+        """Persist benchmark data to the database.
+
+        Args:
+            benchmarks: BenchmarkData objects to insert.
+            source: Data source identifier.
+            confidence_level: Trust level ('benchmarked' or 'estimated').
+
+        Raises:
+            Exception: If the DB write fails.
+        """
+        from planner.knowledge_base.loader import insert_benchmarks
+
+        conn = self._get_connection()
+        try:
+            benchmark_dicts = [b.to_dict() for b in benchmarks]
+            for d in benchmark_dicts:
+                d.setdefault("prompt_tokens", d.get("mean_input_tokens"))
+                d.setdefault("output_tokens", d.get("mean_output_tokens"))
+            insert_benchmarks(
+                conn, benchmark_dicts, source=source, confidence_level=confidence_level
+            )
+        finally:
+            conn.close()
 
     def get_benchmark(
         self,
@@ -380,7 +422,7 @@ class BenchmarkRepository:
                 hardware, hardware_count, framework, requests_per_second, tokens_per_second,
                 mean_input_tokens, mean_output_tokens,
                 prompt_tokens, output_tokens,
-                model_uri
+                model_uri, source, confidence_level
             FROM ranked_configs
             WHERE rn = 1
             ORDER BY model_hf_repo, hardware, hardware_count

--- a/src/planner/knowledge_base/benchmarks.py
+++ b/src/planner/knowledge_base/benchmarks.py
@@ -27,6 +27,8 @@ import os
 import psycopg2
 from psycopg2.extras import RealDictCursor
 
+from planner.knowledge_base.loader import insert_benchmarks
+
 logger = logging.getLogger(__name__)
 
 
@@ -173,17 +175,21 @@ class BenchmarkRepository:
         Raises:
             Exception: If the DB write fails.
         """
-        from planner.knowledge_base.loader import insert_benchmarks
+        # Prepare data before opening connection to fail fast and keep
+        # the connection short-lived.
+        benchmark_dicts = [b.to_dict() for b in benchmarks]
+        for d in benchmark_dicts:
+            d.setdefault("prompt_tokens", d.get("mean_input_tokens"))
+            d.setdefault("output_tokens", d.get("mean_output_tokens"))
 
         conn = self._get_connection()
         try:
-            benchmark_dicts = [b.to_dict() for b in benchmarks]
-            for d in benchmark_dicts:
-                d.setdefault("prompt_tokens", d.get("mean_input_tokens"))
-                d.setdefault("output_tokens", d.get("mean_output_tokens"))
             insert_benchmarks(
                 conn, benchmark_dicts, source=source, confidence_level=confidence_level
             )
+        except Exception:
+            conn.rollback()
+            raise
         finally:
             conn.close()
 

--- a/src/planner/knowledge_base/benchmarks.py
+++ b/src/planner/knowledge_base/benchmarks.py
@@ -349,6 +349,7 @@ class BenchmarkRepository:
         min_qps: float = 0,
         percentile: str = "p95",
         gpu_types: list[str] | None = None,
+        exclude_estimated: bool = False,
     ) -> list[BenchmarkData]:
         """
         Find all configurations that meet SLO requirements for a traffic profile.
@@ -368,6 +369,7 @@ class BenchmarkRepository:
             min_qps: Minimum required QPS
             percentile: Which percentile column to use (mean, p90, p95, p99)
             gpu_types: Optional list of GPU types to filter by (normalized canonical names)
+            exclude_estimated: If True, exclude rows with confidence_level='estimated'
 
         Returns:
             List of benchmarks meeting all criteria (one per system configuration)
@@ -383,11 +385,15 @@ class BenchmarkRepository:
         itl_col = f"itl_{percentile}"
         e2e_col = f"e2e_{percentile}"
 
-        # Build optional GPU filter clause
+        # Build optional filter clauses
         gpu_filter = ""
         if gpu_types:
             gpu_filter = "AND hardware = ANY(%s)"
             logger.info(f"Filtering by GPU types: {gpu_types}")
+
+        estimated_filter = ""
+        if exclude_estimated:
+            estimated_filter = "AND confidence_level != 'estimated'"
 
         logger.info(
             f"Querying benchmarks with percentile={percentile} (columns: {ttft_col}, {itl_col}, {e2e_col})"
@@ -412,6 +418,7 @@ class BenchmarkRepository:
                   AND {e2e_col} <= %s
                   AND requests_per_second >= %s
                   {gpu_filter}
+                  {estimated_filter}
             )
             SELECT
                 id, config_id, model_hf_repo, provider, type,

--- a/src/planner/knowledge_base/loader.py
+++ b/src/planner/knowledge_base/loader.py
@@ -60,8 +60,24 @@ def normalize_benchmark_fields(benchmark: dict) -> dict:
     return normalized
 
 
-def prepare_benchmark_for_insert(benchmark: dict) -> dict:
-    """Prepare a benchmark record for database insertion."""
+def prepare_benchmark_for_insert(
+    benchmark: dict,
+    source: str = "local",
+    confidence_level: str = "estimated",
+) -> dict:
+    """Prepare a benchmark record for database insertion.
+
+    Normalizes field names from various JSON formats, generates a UUID
+    and config_id, sets timestamps, and applies source/confidence_level.
+
+    Args:
+        benchmark: Raw benchmark dict (from JSON file or estimation output).
+        source: Data source identifier, e.g. 'blis', 'llm-optimizer'.
+        confidence_level: Trust level — 'benchmarked' or 'estimated'.
+
+    Returns:
+        Dict ready for insertion into exported_summaries.
+    """
     # First normalize field names from different JSON formats
     prepared = normalize_benchmark_fields(benchmark)
 
@@ -97,7 +113,8 @@ def prepare_benchmark_for_insert(benchmark: dict) -> dict:
     prepared.setdefault("profiler_type", None)
     prepared.setdefault("profiler_image", None)
     prepared.setdefault("profiler_tag", None)
-    prepared["source"] = "local"
+    prepared["source"] = source
+    prepared["confidence_level"] = confidence_level
 
     return prepared
 
@@ -119,7 +136,7 @@ _INSERT_QUERY = """
         prompt_tokens, prompt_tokens_stdev, prompt_tokens_min, prompt_tokens_max,
         output_tokens, output_tokens_min, output_tokens_max, output_tokens_stdev,
         profiler_type, profiler_image, profiler_tag,
-        source
+        source, confidence_level
     ) VALUES (
         %(id)s, %(config_id)s, %(model_hf_repo)s, %(provider)s, %(type)s,
         %(ttft_mean)s, %(ttft_p90)s, %(ttft_p95)s, %(ttft_p99)s,
@@ -135,13 +152,18 @@ _INSERT_QUERY = """
         %(prompt_tokens)s, %(prompt_tokens_stdev)s, %(prompt_tokens_min)s, %(prompt_tokens_max)s,
         %(output_tokens)s, %(output_tokens_min)s, %(output_tokens_max)s, %(output_tokens_stdev)s,
         %(profiler_type)s, %(profiler_image)s, %(profiler_tag)s,
-        %(source)s
+        %(source)s, %(confidence_level)s
     )
     ON CONFLICT (config_id) DO NOTHING;
 """
 
 
-def insert_benchmarks(conn, benchmarks: list[dict]) -> dict:
+def insert_benchmarks(
+    conn,
+    benchmarks: list[dict],
+    source: str = "local",
+    confidence_level: str = "estimated",
+) -> dict:
     """Insert benchmarks into the database (append mode).
 
     Duplicates (same config_id) are silently skipped.
@@ -149,6 +171,8 @@ def insert_benchmarks(conn, benchmarks: list[dict]) -> dict:
     Args:
         conn: psycopg2 connection
         benchmarks: List of benchmark dicts from JSON
+        source: Data source identifier (default: "local")
+        confidence_level: Confidence level for the data (default: "estimated")
 
     Returns:
         Dict with insertion stats: {inserted, total_in_db, stats}
@@ -163,7 +187,10 @@ def insert_benchmarks(conn, benchmarks: list[dict]) -> dict:
     conn.commit()
 
     # Prepare benchmarks with required fields
-    prepared_benchmarks = [prepare_benchmark_for_insert(b) for b in benchmarks]
+    prepared_benchmarks = [
+        prepare_benchmark_for_insert(b, source=source, confidence_level=confidence_level)
+        for b in benchmarks
+    ]
 
     logger.info(f"Inserting {len(prepared_benchmarks)} benchmark records...")
     execute_batch(cursor, _INSERT_QUERY, prepared_benchmarks, page_size=100)

--- a/src/planner/knowledge_base/loader.py
+++ b/src/planner/knowledge_base/loader.py
@@ -11,7 +11,7 @@ import logging
 import uuid
 from datetime import datetime
 
-from psycopg2.extras import execute_batch
+from psycopg2.extras import RealDictCursor, execute_batch
 
 logger = logging.getLogger(__name__)
 
@@ -214,7 +214,7 @@ def get_db_stats(conn) -> dict:
         Dict with total_benchmarks, num_models, num_hardware_types,
         num_traffic_profiles, traffic_distribution
     """
-    cursor = conn.cursor()
+    cursor = conn.cursor(cursor_factory=RealDictCursor)
 
     cursor.execute("""
         SELECT
@@ -227,10 +227,10 @@ def get_db_stats(conn) -> dict:
     row = cursor.fetchone()
 
     stats = {
-        "num_models": row[0] if row else 0,
-        "num_hardware_types": row[1] if row else 0,
-        "num_traffic_profiles": row[2] if row else 0,
-        "total_benchmarks": row[3] if row else 0,
+        "num_models": row["num_models"] if row else 0,
+        "num_hardware_types": row["num_hardware_types"] if row else 0,
+        "num_traffic_profiles": row["num_traffic_profiles"] if row else 0,
+        "total_benchmarks": row["total_benchmarks"] if row else 0,
     }
 
     # Get traffic profile distribution
@@ -241,7 +241,12 @@ def get_db_stats(conn) -> dict:
         ORDER BY prompt_tokens, output_tokens;
     """)
     stats["traffic_distribution"] = [
-        {"prompt_tokens": r[0], "output_tokens": r[1], "count": r[2]} for r in cursor.fetchall()
+        {
+            "prompt_tokens": r["prompt_tokens"],
+            "output_tokens": r["output_tokens"],
+            "count": r["num_benchmarks"],
+        }
+        for r in cursor.fetchall()
     ]
 
     cursor.close()

--- a/src/planner/llm/prompts.py
+++ b/src/planner/llm/prompts.py
@@ -8,6 +8,7 @@ Expected JSON schema:
   "user_count": <integer>,
   "domain_specialization": ["general"|"code"|"multilingual"|"enterprise"],
   "preferred_gpu_types": ["<list of GPU types if mentioned, empty list if not specified>"],
+  "preferred_models": ["<list of model IDs in HuggingFace format if mentioned, empty list if not specified>"],
   "accuracy_priority": "low|medium|high",
   "cost_priority": "low|medium|high",
   "latency_priority": "low|medium|high",
@@ -87,6 +88,13 @@ GPU extraction examples (canonical names: L4, A100-40, A100-80, H100, H200, B200
 - "a100-80" or "A100-80GB" → preferred_gpu_types: ["A100-80"]
 - "l4" or "L4" → preferred_gpu_types: ["L4"]
 - No GPU mentioned → preferred_gpu_types: []
+
+Model extraction examples (use HuggingFace format from model catalog):
+- "deploy Llama 3.3 70B" or "use llama 70b" → preferred_models: ["meta-llama/Llama-3.3-70B-Instruct"]
+- "I want to use Qwen3-32B" → preferred_models: ["Qwen/Qwen3-32B"]
+- "compare granite and llama for my use case" → preferred_models: ["ibm-granite/granite-3.1-8b-instruct", "meta-llama/Llama-3.1-8B-Instruct"]
+- "run mistral small" → preferred_models: ["mistralai/Mistral-Small-24B-Instruct-2501"]
+- No model mentioned → preferred_models: []
 
 Priority extraction (for scoring weights - use "medium" as baseline, adjust based on context):
 - accuracy_priority: "high" if user mentions accuracy matters, quality is important, accuracy is critical, best model, or top quality. "low" if user says good enough or accuracy less important.

--- a/src/planner/orchestration/workflow.py
+++ b/src/planner/orchestration/workflow.py
@@ -178,7 +178,7 @@ class RecommendationWorkflow:
         # Detect cluster GPUs for filtering
         cluster_gpu_types = detect_cluster_gpus()
         logger.info("Generating all viable configurations")
-        all_configs = self.config_finder.plan_all_capacities(
+        all_configs, _warnings = self.config_finder.plan_all_capacities(
             traffic_profile=traffic_profile,
             slo_targets=slo_targets,
             intent=intent,
@@ -267,12 +267,14 @@ class RecommendationWorkflow:
         # Detect cluster GPUs for filtering
         cluster_gpu_types = detect_cluster_gpus()
         logger.info("Planning capacity for all model/GPU combinations")
-        all_configs = self.config_finder.plan_all_capacities(
+        all_configs, estimation_warnings = self.config_finder.plan_all_capacities(
             traffic_profile=traffic_profile,
             slo_targets=slo_targets,
             intent=intent,
             include_near_miss=include_near_miss,
             cluster_gpu_types=cluster_gpu_types,
+            preferred_models=intent.preferred_models if intent.preferred_models else None,
+            enable_estimated=True,
         )
 
         if not all_configs:
@@ -284,6 +286,7 @@ class RecommendationWorkflow:
                 specification=specification,
                 total_configs_evaluated=0,
                 configs_after_filters=0,
+                warnings=estimation_warnings,
             )
 
         # Generate ranked lists (top 10 solutions per criterion)
@@ -296,6 +299,7 @@ class RecommendationWorkflow:
             top_n=5,  # Top 5 accuracy models only
             weights=weights,
             use_case=intent.use_case,  # Task bonuses for Balanced
+            preferred_models=intent.preferred_models if intent.preferred_models else None,
         )
 
         # Count configs after filtering
@@ -318,6 +322,7 @@ class RecommendationWorkflow:
             balanced=ranked_lists["balanced"],
             total_configs_evaluated=len(all_configs),
             configs_after_filters=configs_after_filters,
+            warnings=estimation_warnings,
         )
 
     def generate_ranked_recommendations_from_spec(
@@ -327,6 +332,7 @@ class RecommendationWorkflow:
         max_cost: float | None = None,
         include_near_miss: bool = True,
         weights: dict[str, int] | None = None,
+        enable_estimated: bool = True,
     ) -> RankedRecommendationsResponse:
         """
         Generate ranked recommendation lists from pre-built specifications.
@@ -399,13 +405,15 @@ class RecommendationWorkflow:
         cluster_gpu_types = detect_cluster_gpus()
         logger.info("Planning capacity for all model/GPU combinations")
         logger.info(f"Using weights for balanced scoring: {weights}")
-        all_configs = self.config_finder.plan_all_capacities(
+        all_configs, estimation_warnings = self.config_finder.plan_all_capacities(
             traffic_profile=traffic_profile,
             slo_targets=slo_targets,
             intent=intent,
             include_near_miss=include_near_miss,
             weights=weights,
             cluster_gpu_types=cluster_gpu_types,
+            preferred_models=intent.preferred_models if intent.preferred_models else None,
+            enable_estimated=enable_estimated,
         )
 
         if not all_configs:
@@ -417,6 +425,7 @@ class RecommendationWorkflow:
                 specification=specification,
                 total_configs_evaluated=0,
                 configs_after_filters=0,
+                warnings=estimation_warnings,
             )
 
         # Generate ranked lists (top 10 solutions per criterion)
@@ -429,6 +438,7 @@ class RecommendationWorkflow:
             top_n=10,  # Top 10 accuracy models only
             weights=weights,
             use_case=intent.use_case,  # Task bonuses for Balanced
+            preferred_models=intent.preferred_models if intent.preferred_models else None,
         )
 
         # Count configs after filtering
@@ -451,4 +461,5 @@ class RecommendationWorkflow:
             balanced=ranked_lists["balanced"],
             total_configs_evaluated=len(all_configs),
             configs_after_filters=configs_after_filters,
+            warnings=estimation_warnings,
         )

--- a/src/planner/recommendation/analyzer.py
+++ b/src/planner/recommendation/analyzer.py
@@ -238,8 +238,7 @@ class Analyzer:
         }
 
         logger.info(
-            f"Generated ranked lists: {len(filtered)} filtered configs, "
-            f"top {top_n} per criterion"
+            f"Generated ranked lists: {len(filtered)} filtered configs, top {top_n} per criterion"
         )
 
         return ranked_lists

--- a/src/planner/recommendation/analyzer.py
+++ b/src/planner/recommendation/analyzer.py
@@ -1,14 +1,7 @@
 """Ranking service for multi-criteria recommendation sorting.
 
-ACCURACY-FIRST STRATEGY:
-1. Get top N unique models by raw accuracy (quality baseline)
-2. Filter all hardware configs to only these high-quality models
-3. Best Latency/Cost/etc. are ranked WITHIN this quality tier
-
-This ensures:
-- All recommendations show HIGH QUALITY models
-- No "fast but useless" or "cheap but terrible" recommendations
-- Cards show different trade-offs within the same quality tier
+Each card (Best Accuracy, Lowest Cost, Best Latency, Simplest, Balanced)
+ranks ALL filtered configurations independently by its own criterion.
 
 TASK-SPECIFIC BONUSES (Balanced card only):
 - Different model types get bonuses for specific use cases
@@ -157,16 +150,10 @@ class Analyzer:
         top_n: int = 5,
         weights: dict[str, int] | None = None,
         use_case: str | None = None,
+        preferred_models: list[str] | None = None,
     ) -> dict[str, list[DeploymentRecommendation]]:
         """
-        Generate 5 ranked lists using ACCURACY-FIRST strategy.
-
-        Strategy:
-        1. Get top N unique models by raw accuracy (quality baseline)
-        2. Filter ALL hardware configs to only these high-quality models
-        3. Best Latency = fastest hardware among high-quality models
-        4. Best Cost = cheapest hardware among high-quality models
-        5. Balanced = best weighted score among high-quality models
+        Generate 5 ranked lists, each sorted independently by its criterion.
 
         Args:
             configurations: List of scored DeploymentRecommendations
@@ -175,17 +162,14 @@ class Analyzer:
             top_n: Number of top configurations to return per list
             weights: Optional custom weights for balanced score (0-10 scale)
                      Keys: accuracy, price, latency, complexity
+            use_case: Use case identifier (unused, kept for API compatibility)
+            preferred_models: User-specified models that bypass min_accuracy filter
 
         Returns:
             Dict with keys: best_accuracy, lowest_cost, lowest_latency,
                            simplest, balanced
         """
-        # Apply filters
-        filtered = self._apply_filters(configurations, min_accuracy, max_cost)
-
-        # # Recalculate balanced scores with custom weights and task bonuses
-        # if filtered:
-        #     self._recalculate_balanced_scores(filtered, weights or {}, use_case)
+        filtered = self._apply_filters(configurations, min_accuracy, max_cost, preferred_models)
 
         if not filtered:
             logger.warning("No configurations remain after filtering")
@@ -197,17 +181,10 @@ class Analyzer:
                 "balanced": [],
             }
 
-        # =====================================================================
-        # STEP 1: Get top N UNIQUE MODELS by raw accuracy (quality baseline)
-        # Tie-breakers follow priority order: Accuracy → Cost → Latency → Complexity
-        # =====================================================================
-
-        # Helper functions for sort keys (higher score = better, lower cost = better)
         def get_accuracy(x):
             return x.scores.accuracy_score if x.scores else 0
 
         def get_cost_inverted(x):
-            # Invert cost so lower cost sorts higher (better)
             cost = x.cost_per_month_usd or float("inf")
             return -cost
 
@@ -220,20 +197,14 @@ class Analyzer:
         def get_balanced(x):
             return x.scores.balanced_score if x.scores else 0.0
 
-        seen_models = set()
-        unique_accuracy_configs = []
-        # Primary: Accuracy, Tie-breakers: Cost → Latency → Complexity
+        # Best Accuracy: deduplicate by model (one config per model)
+        seen_models: set[str] = set()
+        unique_accuracy_configs: list[DeploymentRecommendation] = []
         sorted_by_accuracy = sorted(
             filtered,
-            key=lambda x: (
-                get_accuracy(x),
-                get_cost_inverted(x),
-                get_latency(x),
-                get_complexity(x),
-            ),
+            key=lambda x: (get_accuracy(x), get_cost_inverted(x), get_latency(x)),
             reverse=True,
         )
-
         for config in sorted_by_accuracy:
             model_name = config.model_name or config.model_id or "Unknown"
             if model_name not in seen_models:
@@ -242,85 +213,33 @@ class Analyzer:
                 if len(unique_accuracy_configs) >= top_n:
                     break
 
-        # Get the model names of top accuracy models
-        top_accuracy_model_names = {c.model_name or c.model_id for c in unique_accuracy_configs}
-
-        logger.info(
-            f"ACCURACY-FIRST: Top {len(top_accuracy_model_names)} models by accuracy: "
-            f"{list(top_accuracy_model_names)[:5]}"
-        )
-
-        # =====================================================================
-        # STEP 2: Filter ALL configs to only high-quality models
-        # This ensures Best Latency and Best Cost show HIGH QUALITY models
-        # =====================================================================
-        high_quality_configs = [
-            c for c in filtered if (c.model_name or c.model_id) in top_accuracy_model_names
-        ]
-
-        logger.info(
-            f"ACCURACY-FIRST: {len(high_quality_configs)} configs from top {len(top_accuracy_model_names)} models"
-        )
-
-        # =====================================================================
-        # STEP 3: Generate ranked lists from HIGH-QUALITY configs only
-        # Tie-breaker order: Accuracy → Cost → Latency → Complexity
-        # Each list excludes its primary criterion from tie-breakers
-        # =====================================================================
         ranked_lists = {
-            # Best Accuracy: Top N unique models (one config per model)
-            # Already sorted with tie-breakers: Cost → Latency → Complexity
             "best_accuracy": unique_accuracy_configs[:top_n],
-            # Best Cost: Primary=Cost, Tie-breakers: Accuracy → Latency → Complexity
             "lowest_cost": sorted(
-                high_quality_configs,
-                key=lambda x: (
-                    get_cost_inverted(x),
-                    get_accuracy(x),
-                    get_latency(x),
-                    get_complexity(x),
-                ),
+                filtered,
+                key=lambda x: (get_cost_inverted(x), get_accuracy(x), get_latency(x)),
                 reverse=True,
             )[:top_n],
-            # Best Latency: Primary=Latency, Tie-breakers: Accuracy → Cost → Complexity
             "lowest_latency": sorted(
-                high_quality_configs,
-                key=lambda x: (
-                    get_latency(x),
-                    get_accuracy(x),
-                    get_cost_inverted(x),
-                    get_complexity(x),
-                ),
+                filtered,
+                key=lambda x: (get_latency(x), get_accuracy(x), get_cost_inverted(x)),
                 reverse=True,
             )[:top_n],
-            # Simplest: Primary=Complexity, Tie-breakers: Accuracy → Cost → Latency
             "simplest": sorted(
-                high_quality_configs,
-                key=lambda x: (
-                    get_complexity(x),
-                    get_accuracy(x),
-                    get_cost_inverted(x),
-                    get_latency(x),
-                ),
+                filtered,
+                key=lambda x: (get_complexity(x), get_accuracy(x), get_cost_inverted(x)),
                 reverse=True,
             )[:top_n],
-            # Balanced: Primary=Balanced, Tie-breakers: Accuracy → Cost → Latency → Complexity
             "balanced": sorted(
-                high_quality_configs,
-                key=lambda x: (
-                    get_balanced(x),
-                    get_accuracy(x),
-                    get_cost_inverted(x),
-                    get_latency(x),
-                    get_complexity(x),
-                ),
+                filtered,
+                key=lambda x: (get_balanced(x), get_accuracy(x), get_cost_inverted(x)),
                 reverse=True,
             )[:top_n],
         }
 
         logger.info(
-            f"Generated ranked lists (ACCURACY-FIRST): {len(filtered)} total configs, "
-            f"{len(high_quality_configs)} high-quality, top {top_n} per criterion"
+            f"Generated ranked lists: {len(filtered)} filtered configs, "
+            f"top {top_n} per criterion"
         )
 
         return ranked_lists
@@ -330,6 +249,7 @@ class Analyzer:
         configs: list[DeploymentRecommendation],
         min_accuracy: int | None,
         max_cost: float | None,
+        preferred_models: list[str] | None = None,
     ) -> list[DeploymentRecommendation]:
         """
         Apply accuracy and cost filters to configurations.
@@ -338,15 +258,22 @@ class Analyzer:
             configs: List of configurations to filter
             min_accuracy: Minimum accuracy score (0-100), None = no filter
             max_cost: Maximum monthly cost (USD), None = no filter
+            preferred_models: User-specified models that bypass min_accuracy filter
 
         Returns:
             Filtered list of configurations
         """
         filtered = configs
 
-        # Filter by minimum accuracy
+        # Filter by minimum accuracy — exempt user-specified preferred models
         if min_accuracy is not None and min_accuracy > 0:
-            filtered = [c for c in filtered if c.scores and c.scores.accuracy_score >= min_accuracy]
+            preferred_set = {m.lower() for m in preferred_models} if preferred_models else set()
+            filtered = [
+                c
+                for c in filtered
+                if (c.scores and c.scores.accuracy_score >= min_accuracy)
+                or (c.model_id and c.model_id.lower() in preferred_set)
+            ]
             logger.debug(f"After min_accuracy={min_accuracy} filter: {len(filtered)} configs")
 
         # Filter by maximum cost

--- a/src/planner/recommendation/config_finder.py
+++ b/src/planner/recommendation/config_finder.py
@@ -290,8 +290,7 @@ class ConfigFinder:
             if estimated_configs:
                 matching_configs.extend(estimated_configs)
                 logger.info(
-                    f"Added {len(estimated_configs)} estimated configurations "
-                    f"from roofline model"
+                    f"Added {len(estimated_configs)} estimated configurations from roofline model"
                 )
 
         # When the user specified preferred models, filter results to only

--- a/src/planner/recommendation/config_finder.py
+++ b/src/planner/recommendation/config_finder.py
@@ -17,10 +17,16 @@ TODO (Phase 2+): Parametric Performance Models
 - Interpolate for in-range predictions with confidence intervals
 """
 
+import contextlib
+import io
 import logging
 import math
+import os
+import time
 from typing import Protocol
 
+from planner.capacity_planner import check_model_fits_gpu, get_model_config_from_hf
+from planner.gpu_recommender import GPURecommender
 from planner.knowledge_base.benchmarks import BenchmarkData, BenchmarkRepository
 from planner.knowledge_base.model_catalog import ModelCatalog, ModelInfo
 from planner.shared.schemas import (
@@ -138,6 +144,293 @@ class ConfigFinder:
 
         return ". ".join(reasons)
 
+    # Mapping from gpu_catalog.json gpu_type to llm_optimizer GPU_SPECS keys.
+    # GPUs not in this map are not supported by the roofline model.
+    _CATALOG_TO_ROOFLINE_GPU: dict[str, str] = {
+        "H100": "H100",
+        "H200": "H200",
+        "A100-80": "A100",
+        "A100-40": "A100-40GB",
+        "L40": "L40",
+        "L20": "L20",
+        "B100": "B100",
+        "B200": "B200",
+    }
+
+    @staticmethod
+    def _convert_estimation_to_benchmark(
+        model_id: str,
+        gpu_type: str,
+        gpu_count: int,
+        prompt_tokens: int,
+        output_tokens: int,
+        ttft_ms: float,
+        itl_ms: float,
+        e2e_latency_ms: float,
+        output_throughput_tps: float,
+    ) -> BenchmarkData:
+        """Convert GPU Recommender roofline output to BenchmarkData format.
+
+        The roofline model produces single-point estimates (no percentile
+        distribution), so the same value is used for mean/p90/p95/p99.
+        """
+        rps = output_throughput_tps / output_tokens if output_tokens > 0 else 0.0
+
+        data = {
+            "model_hf_repo": model_id,
+            "hardware": gpu_type,
+            "hardware_count": gpu_count,
+            "framework": "vllm",
+            "framework_version": "estimated",
+            "prompt_tokens": prompt_tokens,
+            "output_tokens": output_tokens,
+            "mean_input_tokens": prompt_tokens,
+            "mean_output_tokens": output_tokens,
+            "ttft_mean": ttft_ms,
+            "ttft_p90": ttft_ms,
+            "ttft_p95": ttft_ms,
+            "ttft_p99": ttft_ms,
+            "itl_mean": itl_ms,
+            "itl_p90": itl_ms,
+            "itl_p95": itl_ms,
+            "itl_p99": itl_ms,
+            "e2e_mean": e2e_latency_ms,
+            "e2e_p90": e2e_latency_ms,
+            "e2e_p95": e2e_latency_ms,
+            "e2e_p99": e2e_latency_ms,
+            "tps_mean": output_throughput_tps,
+            "tps_p90": output_throughput_tps,
+            "tps_p95": output_throughput_tps,
+            "tps_p99": output_throughput_tps,
+            "tokens_per_second": output_throughput_tps,
+            "requests_per_second": rps,
+            "estimated": True,
+            "source": "llm-optimizer",
+            "confidence_level": "estimated",
+            "model_uri": None,
+        }
+        return BenchmarkData(data)
+
+    def _generate_estimated_configs(
+        self,
+        traffic_profile: TrafficProfile,
+        slo_targets: SLOTargets,
+        preferred_models: list[str],
+        existing_benchmarks: list[BenchmarkData],
+        gpu_types: list[str] | None,
+        estimate_all_catalog: bool = False,
+    ) -> tuple[list[BenchmarkData], list[str]]:
+        """Generate estimated BenchmarkData for (model, GPU) pairs without benchmarks.
+
+        Uses the capacity planner for memory feasibility and the BentoML roofline
+        model for synthetic performance estimation. Results are written to the DB
+        for future cache hits.
+
+        Args:
+            traffic_profile: Current traffic profile (prompt_tokens, output_tokens)
+            slo_targets: SLO targets (TTFT, ITL, E2E)
+            preferred_models: User-specified model IDs (HuggingFace format)
+            existing_benchmarks: Benchmark results already found from DB
+            gpu_types: GPU types to evaluate (None = all catalog GPUs)
+            estimate_all_catalog: If True, also estimate for catalog models
+                                 without benchmarks (not just user-specified)
+
+        Returns:
+            Tuple of (list of new BenchmarkData, list of warning messages)
+        """
+        warnings: list[str] = []
+
+        # 1. Build covered set from existing benchmarks (includes prior roofline estimates)
+        # Key is (model, gpu, tp) so different TP values are estimated independently.
+        covered: set[tuple[str, str, int]] = set()
+        for bench in existing_benchmarks:
+            covered.add((bench.model_hf_repo.lower(), bench.hardware.lower(), bench.hardware_count))
+
+        # 2. Determine models to estimate
+        models_to_estimate: list[str] = []
+        for model_id in preferred_models:
+            models_to_estimate.append(model_id)
+
+        if estimate_all_catalog:
+            for model_info in self.catalog.get_all_models():
+                if model_info.model_id not in models_to_estimate:
+                    models_to_estimate.append(model_info.model_id)
+
+        if not models_to_estimate:
+            return [], warnings
+
+        # 3. Determine GPUs to evaluate
+        if gpu_types:
+            catalog_gpus = [
+                gt for gt in self.catalog.get_all_gpu_types() if gt.gpu_type in gpu_types
+            ]
+        else:
+            catalog_gpus = self.catalog.get_all_gpu_types()
+
+        # Configurable limits
+        max_models = int(os.getenv("PLANNER_ESTIMATED_MAX_MODELS", "5"))
+        timeout_s = int(os.getenv("PLANNER_ESTIMATED_TIMEOUT_S", "60"))
+        models_to_estimate = models_to_estimate[:max_models]
+
+        hf_token = os.getenv("HF_TOKEN")
+        new_benchmarks: list[BenchmarkData] = []
+        start_time = time.monotonic()
+
+        gpu_names = [g.gpu_type for g in catalog_gpus]
+        logger.info(
+            f"Estimation plan: {len(models_to_estimate)} models × "
+            f"{len(catalog_gpus)} GPUs {gpu_names}, "
+            f"{len(covered)} (model, GPU, TP) combinations already covered"
+        )
+        for model_id in models_to_estimate:
+            logger.info(f"  model: {model_id}")
+
+        # 4. For each model, check feasibility and estimate performance
+        for model_idx, model_id in enumerate(models_to_estimate, 1):
+            elapsed = time.monotonic() - start_time
+            if elapsed > timeout_s:
+                remaining = len(models_to_estimate) - model_idx + 1
+                msg = (
+                    f"Estimation timeout ({timeout_s}s) reached after {elapsed:.0f}s. "
+                    f"Skipping {remaining} remaining model(s)."
+                )
+                logger.warning(msg)
+                warnings.append(msg)
+                break
+            logger.info(f"Estimating model {model_idx}/{len(models_to_estimate)}: {model_id}")
+            # Fetch model config from HuggingFace (suppress noisy stdout
+            # from safetensors tqdm progress bar)
+            try:
+                with (
+                    contextlib.redirect_stdout(io.StringIO()),
+                    contextlib.redirect_stderr(io.StringIO()),
+                ):
+                    model_config = get_model_config_from_hf(model_id, hf_token)
+            except Exception as e:
+                msg = f"Could not estimate performance for {model_id}: {e}"
+                logger.warning(msg)
+                warnings.append(msg)
+                continue
+
+            model_had_any_gpu = False
+            model_checked_any_gpu = False
+            model_had_error = False
+
+            for gpu_info in catalog_gpus:
+                # Map catalog GPU name to roofline model name
+                roofline_gpu = self._CATALOG_TO_ROOFLINE_GPU.get(gpu_info.gpu_type)
+                if not roofline_gpu:
+                    continue  # GPU not supported by roofline model
+
+                model_checked_any_gpu = True
+
+                # Check memory feasibility (suppress safetensors tqdm output)
+                try:
+                    with (
+                        contextlib.redirect_stdout(io.StringIO()),
+                        contextlib.redirect_stderr(io.StringIO()),
+                    ):
+                        valid_tps = check_model_fits_gpu(
+                            model_id, model_config, gpu_info.memory_gb, hf_token=hf_token
+                        )
+                except Exception as e:
+                    msg = f"Could not check GPU fit for {model_id} on {gpu_info.gpu_type}: {e}"
+                    logger.warning(msg)
+                    warnings.append(msg)
+                    model_had_error = True
+                    logger.info(f"Skipping remaining GPUs for {model_id} due to model-level error")
+                    break
+                if not valid_tps:
+                    logger.info(
+                        f"  {gpu_info.gpu_type}: model does not fit "
+                        f"({gpu_info.memory_gb}GB) at any TP"
+                    )
+                    continue
+
+                model_had_any_gpu = True
+
+                # Estimate performance at each valid TP value
+                for tp in valid_tps:
+                    # Skip if already covered (e.g., from prior DB benchmark or earlier estimate)
+                    if (model_id.lower(), gpu_info.gpu_type.lower(), tp) in covered:
+                        continue
+
+                    # Run roofline estimation (suppress noisy stdout from
+                    # llm_optimizer click.echo and safetensors tqdm progress)
+                    try:
+                        with (
+                            contextlib.redirect_stdout(io.StringIO()),
+                            contextlib.redirect_stderr(io.StringIO()),
+                        ):
+                            recommender = GPURecommender(
+                                model_id=model_id,
+                                input_len=traffic_profile.prompt_tokens,
+                                output_len=traffic_profile.output_tokens,
+                                max_gpus=tp,
+                                gpu_list=[roofline_gpu],
+                                max_ttft=slo_targets.ttft_p95_target_ms,
+                                max_itl=slo_targets.itl_p95_target_ms,
+                                max_latency=slo_targets.e2e_p95_target_ms / 1000,
+                                catalog=self.catalog,
+                            )
+                            gpu_results, failed_gpus = recommender.get_gpu_results()
+                    except Exception as e:
+                        msg = f"Roofline estimation failed for {model_id} on {gpu_info.gpu_type} TP={tp}: {e}"
+                        logger.warning(msg)
+                        warnings.append(msg)
+                        continue
+
+                    if roofline_gpu in failed_gpus:
+                        # Don't surface per-TP constraint failures as warnings —
+                        # higher TP values may still succeed
+                        continue
+
+                    if roofline_gpu not in gpu_results:
+                        continue
+
+                    result = gpu_results[roofline_gpu]
+                    best_latency = (
+                        result.best_configs.get("best_latency")
+                        if isinstance(result.best_configs, dict)
+                        else None
+                    )
+                    if not best_latency or not hasattr(best_latency, "ttft_ms"):
+                        continue
+
+                    # Convert to BenchmarkData
+                    bench = self._convert_estimation_to_benchmark(
+                        model_id=model_id,
+                        gpu_type=gpu_info.gpu_type,  # Use catalog name for DB consistency
+                        gpu_count=tp,
+                        prompt_tokens=traffic_profile.prompt_tokens,
+                        output_tokens=traffic_profile.output_tokens,
+                        ttft_ms=best_latency.ttft_ms,
+                        itl_ms=best_latency.itl_ms,
+                        e2e_latency_ms=best_latency.e2e_latency_s * 1000,
+                        output_throughput_tps=best_latency.output_throughput_tps,
+                    )
+                    new_benchmarks.append(bench)
+                    covered.add((model_id.lower(), gpu_info.gpu_type.lower(), tp))
+
+            # Only warn "does not fit" when the model genuinely doesn't fit —
+            # not when a network error prevented the check.
+            if not model_had_any_gpu and model_checked_any_gpu and not model_had_error:
+                msg = f"Model {model_id} does not fit on any available GPU"
+                logger.warning(msg)
+                warnings.append(msg)
+
+        # 5. Write new estimates to DB for future cache hits
+        if new_benchmarks:
+            try:
+                self.benchmark_repo.save_benchmarks(new_benchmarks)
+                logger.info(f"Wrote {len(new_benchmarks)} roofline estimates to DB")
+            except Exception as e:
+                msg = f"Failed to persist roofline estimates to DB: {type(e).__name__}: {e}"
+                logger.warning(msg)
+                warnings.append(msg)
+
+        return new_benchmarks, warnings
+
     def plan_all_capacities(
         self,
         traffic_profile: TrafficProfile,
@@ -147,7 +440,9 @@ class ConfigFinder:
         near_miss_tolerance: float = 0.0,  # No near-miss tolerance
         weights: dict[str, int] | None = None,  # Custom weights for balanced score
         cluster_gpu_types: list[str] | None = None,
-    ) -> list[DeploymentRecommendation]:
+        preferred_models: list[str] | None = None,
+        enable_estimated: bool = True,
+    ) -> tuple[list[DeploymentRecommendation], list[str]]:
         """
         Plan GPU capacity and return ALL viable configurations meeting SLO.
 
@@ -165,9 +460,13 @@ class ConfigFinder:
             cluster_gpu_types: Detected GPU types from cluster (None = detection
                 not attempted, [] = no GPUs detected, non-empty = hard filter
                 intersected with user preferences)
+            preferred_models: User-specified model IDs to include via estimated
+                performance when no benchmark data exists
+            enable_estimated: Whether to run roofline estimation for models/GPUs
+                without benchmark data (default True)
 
         Returns:
-            List of DeploymentRecommendations with scores attached
+            Tuple of (list of DeploymentRecommendations with scores, list of warning messages)
         """
         scorer = Scorer()
         all_configs: list[DeploymentRecommendation] = []
@@ -206,7 +505,7 @@ class ConfigFinder:
                         "No overlap between cluster GPUs and user preference — "
                         "no configurations possible"
                     )
-                    return []
+                    return [], []
             else:
                 effective_gpus = sorted(cluster_gpu_types)
                 logger.info(f"Using cluster GPUs as filter: {effective_gpus}")
@@ -252,13 +551,49 @@ class ConfigFinder:
                 gpu_types=None,
             )
 
+        # Estimated performance flow: generate roofline estimates for
+        # preferred models (and optionally catalog models) that lack benchmark data.
+        all_warnings: list[str] = []
+        if enable_estimated and preferred_models:
+            estimated_configs, estimation_warnings = self._generate_estimated_configs(
+                traffic_profile=traffic_profile,
+                slo_targets=slo_targets,
+                preferred_models=preferred_models,
+                existing_benchmarks=matching_configs,
+                gpu_types=normalized_gpus if normalized_gpus else None,
+            )
+            all_warnings.extend(estimation_warnings)
+            if estimated_configs:
+                matching_configs.extend(estimated_configs)
+                logger.info(
+                    f"Added {len(estimated_configs)} estimated configurations "
+                    f"from roofline model"
+                )
+
+        # When the user specified preferred models, filter results to only
+        # those models.  Fall back to all configs if none of the preferred
+        # models produced viable results.
+        if preferred_models:
+            preferred_set = {m.lower() for m in preferred_models}
+            preferred_configs = [
+                c for c in matching_configs if c.model_hf_repo.lower() in preferred_set
+            ]
+            if preferred_configs:
+                logger.info(
+                    f"Filtering to {len(preferred_configs)} configs for "
+                    f"preferred models (from {len(matching_configs)} total)"
+                )
+                matching_configs = preferred_configs
+            else:
+                logger.info("No configs for preferred models — showing all available")
+
         if not matching_configs:
             logger.warning(
                 f"No configurations found for traffic profile "
                 f"({traffic_profile.prompt_tokens}→{traffic_profile.output_tokens})"
                 + (f" with GPUs {normalized_gpus}" if normalized_gpus else "")
             )
-            return []
+            return [], all_warnings
 
         # Build model lookup from catalog for scoring
         # Models not in catalog will get accuracy score = 0
@@ -338,6 +673,12 @@ class ConfigFinder:
 
             accuracy_score = int(raw_accuracy)
 
+            # Fallback: for models without accuracy benchmarks (e.g., estimated models),
+            # use parameter-count-based heuristic so they aren't filtered by min_accuracy
+            if accuracy_score == 0 and getattr(bench, "confidence_level", None) == "estimated":
+                model_size = model.size_parameters if model else bench.model_hf_repo
+                accuracy_score = scorer.score_accuracy_by_size(model_size)
+
             # Apply task-specific bonus to accuracy score
             # This boosts models that are well-suited for the specific use case
             task_bonus = get_task_bonus(model_name_for_scoring, intent.use_case)
@@ -374,6 +715,9 @@ class ConfigFinder:
                 else 0,
                 # Data validation flag: True = estimated/interpolated, False = real benchmark
                 "estimated": getattr(bench, "estimated", False),
+                # Classification fields for UI badges
+                "source": getattr(bench, "source", "other"),
+                "confidence_level": getattr(bench, "confidence_level", "benchmarked"),
             }
 
             # Build recommendation (price score calculated later after we know min/max)
@@ -409,7 +753,7 @@ class ConfigFinder:
 
         if not all_configs:
             logger.warning("No viable configurations found for any model")
-            return []
+            return [], all_warnings
 
         # Now calculate price scores (need min/max across all configs)
         costs = [rec.cost_per_month_usd for rec in all_configs if rec.cost_per_month_usd]
@@ -461,4 +805,4 @@ class ConfigFinder:
         logger.info(
             f"Found {len(all_configs)} viable configurations across {len(unique_models)} models"
         )
-        return all_configs
+        return all_configs, all_warnings

--- a/src/planner/recommendation/config_finder.py
+++ b/src/planner/recommendation/config_finder.py
@@ -17,16 +17,10 @@ TODO (Phase 2+): Parametric Performance Models
 - Interpolate for in-range predictions with confidence intervals
 """
 
-import contextlib
-import io
 import logging
 import math
-import os
-import time
 from typing import Protocol
 
-from planner.capacity_planner import check_model_fits_gpu, get_model_config_from_hf
-from planner.gpu_recommender import GPURecommender
 from planner.knowledge_base.benchmarks import BenchmarkData, BenchmarkRepository
 from planner.knowledge_base.model_catalog import ModelCatalog, ModelInfo
 from planner.shared.schemas import (
@@ -40,6 +34,7 @@ from planner.shared.schemas import (
 from planner.shared.utils import normalize_gpu_types
 
 from .analyzer import get_task_bonus
+from .estimator import generate_estimated_configs
 from .scorer import Scorer
 
 logger = logging.getLogger(__name__)
@@ -143,293 +138,6 @@ class ConfigFinder:
         reasons.append(f"Expected performance: TTFT={ttft_p95}ms (p95), ITL={itl_p95}ms (p95)")
 
         return ". ".join(reasons)
-
-    # Mapping from gpu_catalog.json gpu_type to llm_optimizer GPU_SPECS keys.
-    # GPUs not in this map are not supported by the roofline model.
-    _CATALOG_TO_ROOFLINE_GPU: dict[str, str] = {
-        "H100": "H100",
-        "H200": "H200",
-        "A100-80": "A100",
-        "A100-40": "A100-40GB",
-        "L40": "L40",
-        "L20": "L20",
-        "B100": "B100",
-        "B200": "B200",
-    }
-
-    @staticmethod
-    def _convert_estimation_to_benchmark(
-        model_id: str,
-        gpu_type: str,
-        gpu_count: int,
-        prompt_tokens: int,
-        output_tokens: int,
-        ttft_ms: float,
-        itl_ms: float,
-        e2e_latency_ms: float,
-        output_throughput_tps: float,
-    ) -> BenchmarkData:
-        """Convert GPU Recommender roofline output to BenchmarkData format.
-
-        The roofline model produces single-point estimates (no percentile
-        distribution), so the same value is used for mean/p90/p95/p99.
-        """
-        rps = output_throughput_tps / output_tokens if output_tokens > 0 else 0.0
-
-        data = {
-            "model_hf_repo": model_id,
-            "hardware": gpu_type,
-            "hardware_count": gpu_count,
-            "framework": "vllm",
-            "framework_version": "estimated",
-            "prompt_tokens": prompt_tokens,
-            "output_tokens": output_tokens,
-            "mean_input_tokens": prompt_tokens,
-            "mean_output_tokens": output_tokens,
-            "ttft_mean": ttft_ms,
-            "ttft_p90": ttft_ms,
-            "ttft_p95": ttft_ms,
-            "ttft_p99": ttft_ms,
-            "itl_mean": itl_ms,
-            "itl_p90": itl_ms,
-            "itl_p95": itl_ms,
-            "itl_p99": itl_ms,
-            "e2e_mean": e2e_latency_ms,
-            "e2e_p90": e2e_latency_ms,
-            "e2e_p95": e2e_latency_ms,
-            "e2e_p99": e2e_latency_ms,
-            "tps_mean": output_throughput_tps,
-            "tps_p90": output_throughput_tps,
-            "tps_p95": output_throughput_tps,
-            "tps_p99": output_throughput_tps,
-            "tokens_per_second": output_throughput_tps,
-            "requests_per_second": rps,
-            "estimated": True,
-            "source": "llm-optimizer",
-            "confidence_level": "estimated",
-            "model_uri": None,
-        }
-        return BenchmarkData(data)
-
-    def _generate_estimated_configs(
-        self,
-        traffic_profile: TrafficProfile,
-        slo_targets: SLOTargets,
-        preferred_models: list[str],
-        existing_benchmarks: list[BenchmarkData],
-        gpu_types: list[str] | None,
-        estimate_all_catalog: bool = False,
-    ) -> tuple[list[BenchmarkData], list[str]]:
-        """Generate estimated BenchmarkData for (model, GPU) pairs without benchmarks.
-
-        Uses the capacity planner for memory feasibility and the BentoML roofline
-        model for synthetic performance estimation. Results are written to the DB
-        for future cache hits.
-
-        Args:
-            traffic_profile: Current traffic profile (prompt_tokens, output_tokens)
-            slo_targets: SLO targets (TTFT, ITL, E2E)
-            preferred_models: User-specified model IDs (HuggingFace format)
-            existing_benchmarks: Benchmark results already found from DB
-            gpu_types: GPU types to evaluate (None = all catalog GPUs)
-            estimate_all_catalog: If True, also estimate for catalog models
-                                 without benchmarks (not just user-specified)
-
-        Returns:
-            Tuple of (list of new BenchmarkData, list of warning messages)
-        """
-        warnings: list[str] = []
-
-        # 1. Build covered set from existing benchmarks (includes prior roofline estimates)
-        # Key is (model, gpu, tp) so different TP values are estimated independently.
-        covered: set[tuple[str, str, int]] = set()
-        for bench in existing_benchmarks:
-            covered.add((bench.model_hf_repo.lower(), bench.hardware.lower(), bench.hardware_count))
-
-        # 2. Determine models to estimate
-        models_to_estimate: list[str] = []
-        for model_id in preferred_models:
-            models_to_estimate.append(model_id)
-
-        if estimate_all_catalog:
-            for model_info in self.catalog.get_all_models():
-                if model_info.model_id not in models_to_estimate:
-                    models_to_estimate.append(model_info.model_id)
-
-        if not models_to_estimate:
-            return [], warnings
-
-        # 3. Determine GPUs to evaluate
-        if gpu_types:
-            catalog_gpus = [
-                gt for gt in self.catalog.get_all_gpu_types() if gt.gpu_type in gpu_types
-            ]
-        else:
-            catalog_gpus = self.catalog.get_all_gpu_types()
-
-        # Configurable limits
-        max_models = int(os.getenv("PLANNER_ESTIMATED_MAX_MODELS", "5"))
-        timeout_s = int(os.getenv("PLANNER_ESTIMATED_TIMEOUT_S", "60"))
-        models_to_estimate = models_to_estimate[:max_models]
-
-        hf_token = os.getenv("HF_TOKEN")
-        new_benchmarks: list[BenchmarkData] = []
-        start_time = time.monotonic()
-
-        gpu_names = [g.gpu_type for g in catalog_gpus]
-        logger.info(
-            f"Estimation plan: {len(models_to_estimate)} models × "
-            f"{len(catalog_gpus)} GPUs {gpu_names}, "
-            f"{len(covered)} (model, GPU, TP) combinations already covered"
-        )
-        for model_id in models_to_estimate:
-            logger.info(f"  model: {model_id}")
-
-        # 4. For each model, check feasibility and estimate performance
-        for model_idx, model_id in enumerate(models_to_estimate, 1):
-            elapsed = time.monotonic() - start_time
-            if elapsed > timeout_s:
-                remaining = len(models_to_estimate) - model_idx + 1
-                msg = (
-                    f"Estimation timeout ({timeout_s}s) reached after {elapsed:.0f}s. "
-                    f"Skipping {remaining} remaining model(s)."
-                )
-                logger.warning(msg)
-                warnings.append(msg)
-                break
-            logger.info(f"Estimating model {model_idx}/{len(models_to_estimate)}: {model_id}")
-            # Fetch model config from HuggingFace (suppress noisy stdout
-            # from safetensors tqdm progress bar)
-            try:
-                with (
-                    contextlib.redirect_stdout(io.StringIO()),
-                    contextlib.redirect_stderr(io.StringIO()),
-                ):
-                    model_config = get_model_config_from_hf(model_id, hf_token)
-            except Exception as e:
-                msg = f"Could not estimate performance for {model_id}: {e}"
-                logger.warning(msg)
-                warnings.append(msg)
-                continue
-
-            model_had_any_gpu = False
-            model_checked_any_gpu = False
-            model_had_error = False
-
-            for gpu_info in catalog_gpus:
-                # Map catalog GPU name to roofline model name
-                roofline_gpu = self._CATALOG_TO_ROOFLINE_GPU.get(gpu_info.gpu_type)
-                if not roofline_gpu:
-                    continue  # GPU not supported by roofline model
-
-                model_checked_any_gpu = True
-
-                # Check memory feasibility (suppress safetensors tqdm output)
-                try:
-                    with (
-                        contextlib.redirect_stdout(io.StringIO()),
-                        contextlib.redirect_stderr(io.StringIO()),
-                    ):
-                        valid_tps = check_model_fits_gpu(
-                            model_id, model_config, gpu_info.memory_gb, hf_token=hf_token
-                        )
-                except Exception as e:
-                    msg = f"Could not check GPU fit for {model_id} on {gpu_info.gpu_type}: {e}"
-                    logger.warning(msg)
-                    warnings.append(msg)
-                    model_had_error = True
-                    logger.info(f"Skipping remaining GPUs for {model_id} due to model-level error")
-                    break
-                if not valid_tps:
-                    logger.info(
-                        f"  {gpu_info.gpu_type}: model does not fit "
-                        f"({gpu_info.memory_gb}GB) at any TP"
-                    )
-                    continue
-
-                model_had_any_gpu = True
-
-                # Estimate performance at each valid TP value
-                for tp in valid_tps:
-                    # Skip if already covered (e.g., from prior DB benchmark or earlier estimate)
-                    if (model_id.lower(), gpu_info.gpu_type.lower(), tp) in covered:
-                        continue
-
-                    # Run roofline estimation (suppress noisy stdout from
-                    # llm_optimizer click.echo and safetensors tqdm progress)
-                    try:
-                        with (
-                            contextlib.redirect_stdout(io.StringIO()),
-                            contextlib.redirect_stderr(io.StringIO()),
-                        ):
-                            recommender = GPURecommender(
-                                model_id=model_id,
-                                input_len=traffic_profile.prompt_tokens,
-                                output_len=traffic_profile.output_tokens,
-                                max_gpus=tp,
-                                gpu_list=[roofline_gpu],
-                                max_ttft=slo_targets.ttft_p95_target_ms,
-                                max_itl=slo_targets.itl_p95_target_ms,
-                                max_latency=slo_targets.e2e_p95_target_ms / 1000,
-                                catalog=self.catalog,
-                            )
-                            gpu_results, failed_gpus = recommender.get_gpu_results()
-                    except Exception as e:
-                        msg = f"Roofline estimation failed for {model_id} on {gpu_info.gpu_type} TP={tp}: {e}"
-                        logger.warning(msg)
-                        warnings.append(msg)
-                        continue
-
-                    if roofline_gpu in failed_gpus:
-                        # Don't surface per-TP constraint failures as warnings —
-                        # higher TP values may still succeed
-                        continue
-
-                    if roofline_gpu not in gpu_results:
-                        continue
-
-                    result = gpu_results[roofline_gpu]
-                    best_latency = (
-                        result.best_configs.get("best_latency")
-                        if isinstance(result.best_configs, dict)
-                        else None
-                    )
-                    if not best_latency or not hasattr(best_latency, "ttft_ms"):
-                        continue
-
-                    # Convert to BenchmarkData
-                    bench = self._convert_estimation_to_benchmark(
-                        model_id=model_id,
-                        gpu_type=gpu_info.gpu_type,  # Use catalog name for DB consistency
-                        gpu_count=tp,
-                        prompt_tokens=traffic_profile.prompt_tokens,
-                        output_tokens=traffic_profile.output_tokens,
-                        ttft_ms=best_latency.ttft_ms,
-                        itl_ms=best_latency.itl_ms,
-                        e2e_latency_ms=best_latency.e2e_latency_s * 1000,
-                        output_throughput_tps=best_latency.output_throughput_tps,
-                    )
-                    new_benchmarks.append(bench)
-                    covered.add((model_id.lower(), gpu_info.gpu_type.lower(), tp))
-
-            # Only warn "does not fit" when the model genuinely doesn't fit —
-            # not when a network error prevented the check.
-            if not model_had_any_gpu and model_checked_any_gpu and not model_had_error:
-                msg = f"Model {model_id} does not fit on any available GPU"
-                logger.warning(msg)
-                warnings.append(msg)
-
-        # 5. Write new estimates to DB for future cache hits
-        if new_benchmarks:
-            try:
-                self.benchmark_repo.save_benchmarks(new_benchmarks)
-                logger.info(f"Wrote {len(new_benchmarks)} roofline estimates to DB")
-            except Exception as e:
-                msg = f"Failed to persist roofline estimates to DB: {type(e).__name__}: {e}"
-                logger.warning(msg)
-                warnings.append(msg)
-
-        return new_benchmarks, warnings
 
     def plan_all_capacities(
         self,
@@ -569,12 +277,14 @@ class ConfigFinder:
         # Estimated performance flow: generate roofline estimates for
         # preferred models (and optionally catalog models) that lack benchmark data.
         if enable_estimated and preferred_models:
-            estimated_configs, estimation_warnings = self._generate_estimated_configs(
+            estimated_configs, estimation_warnings = generate_estimated_configs(
                 traffic_profile=traffic_profile,
                 slo_targets=slo_targets,
                 preferred_models=preferred_models,
                 existing_benchmarks=matching_configs,
                 gpu_types=normalized_gpus if normalized_gpus and not gpu_fallback else None,
+                catalog=self.catalog,
+                benchmark_repo=self.benchmark_repo,
             )
             all_warnings.extend(estimation_warnings)
             if estimated_configs:

--- a/src/planner/recommendation/config_finder.py
+++ b/src/planner/recommendation/config_finder.py
@@ -531,15 +531,29 @@ class ConfigFinder:
             min_qps=0,
             percentile=percentile,
             gpu_types=normalized_gpus if normalized_gpus else None,
+            exclude_estimated=not enable_estimated,
         )
 
-        # Fallback: if cluster-detected GPUs had no benchmark data, retry
+        # Fallback: if the GPU filter produced no benchmark data, retry
         # without GPU filter so the user still gets recommendations.
-        if not matching_configs and normalized_gpus and gpu_filter_from_cluster:
-            logger.warning(
-                f"No benchmarks found for cluster GPUs {normalized_gpus} — "
-                f"falling back to all available GPUs"
-            )
+        all_warnings: list[str] = []
+        gpu_fallback = False
+        if not matching_configs and normalized_gpus:
+            if gpu_filter_from_cluster:
+                msg = (
+                    f"No benchmarks found for cluster GPUs "
+                    f"({', '.join(normalized_gpus)}). "
+                    f"Showing other available GPU configurations."
+                )
+            else:
+                msg = (
+                    f"No configurations found for preferred GPUs "
+                    f"({', '.join(intent.preferred_gpu_types)}). "
+                    f"Showing other available GPU configurations."
+                )
+            logger.warning(msg)
+            all_warnings.append(msg)
+            gpu_fallback = True
             matching_configs = self.benchmark_repo.find_configurations_meeting_slo(
                 prompt_tokens=traffic_profile.prompt_tokens,
                 output_tokens=traffic_profile.output_tokens,
@@ -549,18 +563,18 @@ class ConfigFinder:
                 min_qps=0,
                 percentile=percentile,
                 gpu_types=None,
+                exclude_estimated=not enable_estimated,
             )
 
         # Estimated performance flow: generate roofline estimates for
         # preferred models (and optionally catalog models) that lack benchmark data.
-        all_warnings: list[str] = []
         if enable_estimated and preferred_models:
             estimated_configs, estimation_warnings = self._generate_estimated_configs(
                 traffic_profile=traffic_profile,
                 slo_targets=slo_targets,
                 preferred_models=preferred_models,
                 existing_benchmarks=matching_configs,
-                gpu_types=normalized_gpus if normalized_gpus else None,
+                gpu_types=normalized_gpus if normalized_gpus and not gpu_fallback else None,
             )
             all_warnings.extend(estimation_warnings)
             if estimated_configs:
@@ -585,7 +599,13 @@ class ConfigFinder:
                 )
                 matching_configs = preferred_configs
             else:
-                logger.info("No configs for preferred models — showing all available")
+                model_list = ", ".join(preferred_models)
+                msg = (
+                    f"No configurations found for preferred models "
+                    f"({model_list}). Showing other available solutions."
+                )
+                logger.warning(msg)
+                all_warnings.append(msg)
 
         if not matching_configs:
             logger.warning(

--- a/src/planner/recommendation/estimator.py
+++ b/src/planner/recommendation/estimator.py
@@ -221,8 +221,7 @@ def generate_estimated_configs(
                 break
             if not valid_tps:
                 logger.info(
-                    f"  {gpu_info.gpu_type}: model does not fit "
-                    f"({gpu_info.memory_gb}GB) at any TP"
+                    f"  {gpu_info.gpu_type}: model does not fit ({gpu_info.memory_gb}GB) at any TP"
                 )
                 continue
 

--- a/src/planner/recommendation/estimator.py
+++ b/src/planner/recommendation/estimator.py
@@ -1,0 +1,307 @@
+"""Performance estimation via roofline model.
+
+Generates synthetic BenchmarkData for (model, GPU) pairs that lack real
+benchmark data, using the BentoML llm-optimizer roofline model.
+
+Extracted from ConfigFinder to isolate estimation as a separate concern
+from capacity planning and scoring logic.
+"""
+
+import contextlib
+import io
+import logging
+import os
+import time
+
+from planner.capacity_planner import check_model_fits_gpu, get_model_config_from_hf
+from planner.gpu_recommender import GPURecommender
+from planner.knowledge_base.benchmarks import BenchmarkData, BenchmarkRepository
+from planner.knowledge_base.model_catalog import ModelCatalog
+from planner.shared.schemas import SLOTargets, TrafficProfile
+
+logger = logging.getLogger(__name__)
+
+# Mapping from gpu_catalog.json gpu_type to llm_optimizer GPU_SPECS keys.
+# GPUs not in this map are not supported by the roofline model.
+CATALOG_TO_ROOFLINE_GPU: dict[str, str] = {
+    "H100": "H100",
+    "H200": "H200",
+    "A100-80": "A100",
+    "A100-40": "A100-40GB",
+    "L40": "L40",
+    "L20": "L20",
+    "B100": "B100",
+    "B200": "B200",
+}
+
+
+@contextlib.contextmanager
+def _suppress_noisy_output():
+    """Suppress stdout/stderr from HuggingFace, safetensors tqdm, and llm_optimizer."""
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        yield
+
+
+def convert_estimation_to_benchmark(
+    model_id: str,
+    gpu_type: str,
+    gpu_count: int,
+    prompt_tokens: int,
+    output_tokens: int,
+    ttft_ms: float,
+    itl_ms: float,
+    e2e_latency_ms: float,
+    output_throughput_tps: float,
+) -> BenchmarkData:
+    """Convert GPU Recommender roofline output to BenchmarkData format.
+
+    The roofline model produces single-point estimates (no percentile
+    distribution), so the same value is used for mean/p90/p95/p99.
+    """
+    rps = output_throughput_tps / output_tokens if output_tokens > 0 else 0.0
+
+    data = {
+        "model_hf_repo": model_id,
+        "hardware": gpu_type,
+        "hardware_count": gpu_count,
+        "framework": "vllm",
+        "framework_version": "estimated",
+        "prompt_tokens": prompt_tokens,
+        "output_tokens": output_tokens,
+        "mean_input_tokens": prompt_tokens,
+        "mean_output_tokens": output_tokens,
+        "ttft_mean": ttft_ms,
+        "ttft_p90": ttft_ms,
+        "ttft_p95": ttft_ms,
+        "ttft_p99": ttft_ms,
+        "itl_mean": itl_ms,
+        "itl_p90": itl_ms,
+        "itl_p95": itl_ms,
+        "itl_p99": itl_ms,
+        "e2e_mean": e2e_latency_ms,
+        "e2e_p90": e2e_latency_ms,
+        "e2e_p95": e2e_latency_ms,
+        "e2e_p99": e2e_latency_ms,
+        "tps_mean": output_throughput_tps,
+        "tps_p90": output_throughput_tps,
+        "tps_p95": output_throughput_tps,
+        "tps_p99": output_throughput_tps,
+        "tokens_per_second": output_throughput_tps,
+        "requests_per_second": rps,
+        "estimated": True,
+        "source": "llm-optimizer",
+        "confidence_level": "estimated",
+        "model_uri": None,
+    }
+    return BenchmarkData(data)
+
+
+def generate_estimated_configs(
+    traffic_profile: TrafficProfile,
+    slo_targets: SLOTargets,
+    preferred_models: list[str],
+    existing_benchmarks: list[BenchmarkData],
+    gpu_types: list[str] | None,
+    catalog: ModelCatalog,
+    benchmark_repo: BenchmarkRepository,
+    estimate_all_catalog: bool = False,
+) -> tuple[list[BenchmarkData], list[str]]:
+    """Generate estimated BenchmarkData for (model, GPU) pairs without benchmarks.
+
+    Uses the capacity planner for memory feasibility and the BentoML roofline
+    model for synthetic performance estimation. Results are written to the DB
+    for future cache hits.
+
+    Args:
+        traffic_profile: Current traffic profile (prompt_tokens, output_tokens)
+        slo_targets: SLO targets (TTFT, ITL, E2E)
+        preferred_models: User-specified model IDs (HuggingFace format)
+        existing_benchmarks: Benchmark results already found from DB
+        gpu_types: GPU types to evaluate (None = all catalog GPUs)
+        catalog: Model catalog for GPU info
+        benchmark_repo: Repository for persisting estimates
+        estimate_all_catalog: If True, also estimate for catalog models
+                             without benchmarks (not just user-specified)
+
+    Returns:
+        Tuple of (list of new BenchmarkData, list of warning messages)
+    """
+    warnings: list[str] = []
+
+    # 1. Build covered set from existing benchmarks (includes prior roofline estimates)
+    # Key is (model, gpu, tp) so different TP values are estimated independently.
+    covered: set[tuple[str, str, int]] = set()
+    for bench in existing_benchmarks:
+        covered.add((bench.model_hf_repo.lower(), bench.hardware.lower(), bench.hardware_count))
+
+    # 2. Determine models to estimate
+    models_to_estimate: list[str] = []
+    for model_id in preferred_models:
+        models_to_estimate.append(model_id)
+
+    if estimate_all_catalog:
+        for model_info in catalog.get_all_models():
+            if model_info.model_id not in models_to_estimate:
+                models_to_estimate.append(model_info.model_id)
+
+    if not models_to_estimate:
+        return [], warnings
+
+    # 3. Determine GPUs to evaluate
+    if gpu_types:
+        catalog_gpus = [gt for gt in catalog.get_all_gpu_types() if gt.gpu_type in gpu_types]
+    else:
+        catalog_gpus = catalog.get_all_gpu_types()
+
+    # Configurable limits
+    max_models = int(os.getenv("PLANNER_ESTIMATED_MAX_MODELS", "5"))
+    timeout_s = int(os.getenv("PLANNER_ESTIMATED_TIMEOUT_S", "60"))
+    models_to_estimate = models_to_estimate[:max_models]
+
+    hf_token = os.getenv("HF_TOKEN")
+    new_benchmarks: list[BenchmarkData] = []
+    start_time = time.monotonic()
+
+    gpu_names = [g.gpu_type for g in catalog_gpus]
+    logger.info(
+        f"Estimation plan: {len(models_to_estimate)} models \u00d7 "
+        f"{len(catalog_gpus)} GPUs {gpu_names}, "
+        f"{len(covered)} (model, GPU, TP) combinations already covered"
+    )
+    for model_id in models_to_estimate:
+        logger.info(f"  model: {model_id}")
+
+    # 4. For each model, check feasibility and estimate performance
+    for model_idx, model_id in enumerate(models_to_estimate, 1):
+        elapsed = time.monotonic() - start_time
+        if elapsed > timeout_s:
+            remaining = len(models_to_estimate) - model_idx + 1
+            msg = (
+                f"Estimation timeout ({timeout_s}s) reached after {elapsed:.0f}s. "
+                f"Skipping {remaining} remaining model(s)."
+            )
+            logger.warning(msg)
+            warnings.append(msg)
+            break
+        logger.info(f"Estimating model {model_idx}/{len(models_to_estimate)}: {model_id}")
+        # Fetch model config from HuggingFace
+        try:
+            with _suppress_noisy_output():
+                model_config = get_model_config_from_hf(model_id, hf_token)
+        except Exception as e:
+            msg = f"Could not estimate performance for {model_id}: {e}"
+            logger.warning(msg)
+            warnings.append(msg)
+            continue
+
+        model_had_any_gpu = False
+        model_checked_any_gpu = False
+        model_had_error = False
+
+        for gpu_info in catalog_gpus:
+            # Map catalog GPU name to roofline model name
+            roofline_gpu = CATALOG_TO_ROOFLINE_GPU.get(gpu_info.gpu_type)
+            if not roofline_gpu:
+                continue  # GPU not supported by roofline model
+
+            model_checked_any_gpu = True
+
+            # Check memory feasibility
+            try:
+                with _suppress_noisy_output():
+                    valid_tps = check_model_fits_gpu(
+                        model_id, model_config, gpu_info.memory_gb, hf_token=hf_token
+                    )
+            except Exception as e:
+                msg = f"Could not check GPU fit for {model_id} on {gpu_info.gpu_type}: {e}"
+                logger.warning(msg)
+                warnings.append(msg)
+                model_had_error = True
+                logger.info(f"Skipping remaining GPUs for {model_id} due to model-level error")
+                break
+            if not valid_tps:
+                logger.info(
+                    f"  {gpu_info.gpu_type}: model does not fit "
+                    f"({gpu_info.memory_gb}GB) at any TP"
+                )
+                continue
+
+            model_had_any_gpu = True
+
+            # Estimate performance at each valid TP value
+            for tp in valid_tps:
+                # Skip if already covered (e.g., from prior DB benchmark or earlier estimate)
+                if (model_id.lower(), gpu_info.gpu_type.lower(), tp) in covered:
+                    continue
+
+                # Run roofline estimation
+                try:
+                    with _suppress_noisy_output():
+                        recommender = GPURecommender(
+                            model_id=model_id,
+                            input_len=traffic_profile.prompt_tokens,
+                            output_len=traffic_profile.output_tokens,
+                            max_gpus=tp,
+                            gpu_list=[roofline_gpu],
+                            max_ttft=slo_targets.ttft_p95_target_ms,
+                            max_itl=slo_targets.itl_p95_target_ms,
+                            max_latency=slo_targets.e2e_p95_target_ms / 1000,
+                            catalog=catalog,
+                        )
+                        gpu_results, failed_gpus = recommender.get_gpu_results()
+                except Exception as e:
+                    msg = f"Roofline estimation failed for {model_id} on {gpu_info.gpu_type} TP={tp}: {e}"
+                    logger.warning(msg)
+                    warnings.append(msg)
+                    continue
+
+                if roofline_gpu in failed_gpus:
+                    # Don't surface per-TP constraint failures as warnings —
+                    # higher TP values may still succeed
+                    continue
+
+                if roofline_gpu not in gpu_results:
+                    continue
+
+                result = gpu_results[roofline_gpu]
+                best_latency = (
+                    result.best_configs.get("best_latency")
+                    if isinstance(result.best_configs, dict)
+                    else None
+                )
+                if not best_latency or not hasattr(best_latency, "ttft_ms"):
+                    continue
+
+                # Convert to BenchmarkData
+                bench = convert_estimation_to_benchmark(
+                    model_id=model_id,
+                    gpu_type=gpu_info.gpu_type,  # Use catalog name for DB consistency
+                    gpu_count=tp,
+                    prompt_tokens=traffic_profile.prompt_tokens,
+                    output_tokens=traffic_profile.output_tokens,
+                    ttft_ms=best_latency.ttft_ms,
+                    itl_ms=best_latency.itl_ms,
+                    e2e_latency_ms=best_latency.e2e_latency_s * 1000,
+                    output_throughput_tps=best_latency.output_throughput_tps,
+                )
+                new_benchmarks.append(bench)
+                covered.add((model_id.lower(), gpu_info.gpu_type.lower(), tp))
+
+        # Only warn "does not fit" when the model genuinely doesn't fit —
+        # not when a network error prevented the check.
+        if not model_had_any_gpu and model_checked_any_gpu and not model_had_error:
+            msg = f"Model {model_id} does not fit on any available GPU"
+            logger.warning(msg)
+            warnings.append(msg)
+
+    # 5. Write new estimates to DB for future cache hits
+    if new_benchmarks:
+        try:
+            benchmark_repo.save_benchmarks(new_benchmarks)
+            logger.info(f"Wrote {len(new_benchmarks)} roofline estimates to DB")
+        except Exception as e:
+            msg = f"Failed to persist roofline estimates to DB: {type(e).__name__}: {e}"
+            logger.warning(msg)
+            warnings.append(msg)
+
+    return new_benchmarks, warnings

--- a/src/planner/recommendation/scorer.py
+++ b/src/planner/recommendation/scorer.py
@@ -161,14 +161,16 @@ class Scorer:
                 return int(quality_score)
 
         # Fallback to size-based heuristic (Andre's original logic)
-        return self._score_accuracy_by_size(model_size_str)
+        return self.score_accuracy_by_size(model_size_str)
 
-    def _score_accuracy_by_size(self, model_size_str: str) -> int:
+    def score_accuracy_by_size(self, model_size_str: str) -> int:
         """
         Score model accuracy based on parameter count tier (fallback).
 
         Args:
-            model_size_str: Model size string (e.g., "8B", "70B", "8x7B")
+            model_size_str: Model size or HuggingFace model ID containing a
+                size pattern (e.g., "8B", "70B", "8x7B",
+                "meta-llama/Llama-3.3-70B-Instruct").
 
         Returns:
             Score 0-100

--- a/src/planner/shared/schemas/intent.py
+++ b/src/planner/shared/schemas/intent.py
@@ -38,6 +38,12 @@ class DeploymentIntent(BaseModel):
         "Canonical names: L4, A100-40, A100-80, H100, H200, B200",
     )
 
+    preferred_models: list[str] = Field(
+        default_factory=list,
+        description="List of user's preferred model IDs (HuggingFace format, empty = any model). "
+        "Can be catalog model_ids or arbitrary HF repo IDs.",
+    )
+
     # Priority hints extracted from natural language (used for weight calculation)
     accuracy_priority: Literal["low", "medium", "high"] = Field(
         default="medium", description="Accuracy/quality importance"

--- a/src/planner/shared/schemas/recommendation.py
+++ b/src/planner/shared/schemas/recommendation.py
@@ -149,3 +149,9 @@ class RankedRecommendationsResponse(BaseModel):
     configs_after_filters: int = Field(
         default=0, description="Number of configurations after applying filters"
     )
+
+    # Warnings from estimated performance flow
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Warnings from estimated performance (e.g., unsupported model architectures)",
+    )

--- a/tests/integration/test_estimated_performance_integration.py
+++ b/tests/integration/test_estimated_performance_integration.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from planner.recommendation.config_finder import ConfigFinder
+from planner.recommendation.estimator import generate_estimated_configs
 from planner.shared.schemas import SLOTargets, TrafficProfile
 
 
@@ -44,19 +45,19 @@ class TestEstimatedPerformanceIntegration:
         mock_catalog.get_all_gpu_types.return_value = [gpu_h100]
         mock_catalog.get_all_models.return_value = []
 
-        self.finder = ConfigFinder(
-            benchmark_repo=mock_repo,
-            catalog=mock_catalog,
-        )
+        self.mock_repo = mock_repo
+        self.mock_catalog = mock_catalog
 
     def test_small_model_produces_estimate(self):
         """Qwen2.5-0.5B on H100 should produce a valid estimated benchmark."""
-        results, warnings = self.finder._generate_estimated_configs(
+        results, warnings = generate_estimated_configs(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             preferred_models=["Qwen/Qwen2.5-0.5B"],
             existing_benchmarks=[],
             gpu_types=["H100"],
+            catalog=self.mock_catalog,
+            benchmark_repo=self.mock_repo,
         )
 
         # Filter out non-blocking warnings (e.g., DB persistence failures)
@@ -86,12 +87,14 @@ class TestEstimatedPerformanceIntegration:
 
     def test_nonexistent_model_produces_warning(self):
         """A model ID that doesn't exist on HuggingFace should warn, not crash."""
-        results, warnings = self.finder._generate_estimated_configs(
+        results, warnings = generate_estimated_configs(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             preferred_models=["nonexistent-org/this-model-does-not-exist-12345"],
             existing_benchmarks=[],
             gpu_types=["H100"],
+            catalog=self.mock_catalog,
+            benchmark_repo=self.mock_repo,
         )
 
         assert len(results) == 0
@@ -135,12 +138,14 @@ class TestEstimatedPerformanceIntegration:
             }
         )
 
-        results, warnings = self.finder._generate_estimated_configs(
+        results, warnings = generate_estimated_configs(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             preferred_models=["Qwen/Qwen2.5-0.5B"],
             existing_benchmarks=[existing],
             gpu_types=["H100"],
+            catalog=self.mock_catalog,
+            benchmark_repo=self.mock_repo,
         )
 
         # TP=1 is covered — it should not appear in results.

--- a/tests/integration/test_estimated_performance_integration.py
+++ b/tests/integration/test_estimated_performance_integration.py
@@ -1,0 +1,149 @@
+"""Integration test for estimated performance flow.
+
+Exercises the full estimation pipeline with real HuggingFace API calls
+and the real llm_optimizer library — no mocks.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from planner.recommendation.config_finder import ConfigFinder
+from planner.shared.schemas import SLOTargets, TrafficProfile
+
+
+def _make_traffic() -> TrafficProfile:
+    return TrafficProfile(
+        prompt_tokens=512,
+        output_tokens=256,
+        expected_qps=5.0,
+    )
+
+
+def _make_slo() -> SLOTargets:
+    return SLOTargets(
+        ttft_p95_target_ms=500,
+        itl_p95_target_ms=50,
+        e2e_p95_target_ms=15000,
+    )
+
+
+@pytest.mark.integration
+class TestEstimatedPerformanceIntegration:
+    """End-to-end tests that hit real HuggingFace API and llm_optimizer."""
+
+    def setup_method(self):
+        mock_repo = MagicMock()
+        mock_repo._get_connection.return_value = MagicMock()
+
+        mock_catalog = MagicMock()
+        # Set up H100 as the only GPU (supported by roofline model)
+        gpu_h100 = MagicMock()
+        gpu_h100.gpu_type = "H100"
+        gpu_h100.memory_gb = 80
+        mock_catalog.get_all_gpu_types.return_value = [gpu_h100]
+        mock_catalog.get_all_models.return_value = []
+
+        self.finder = ConfigFinder(
+            benchmark_repo=mock_repo,
+            catalog=mock_catalog,
+        )
+
+    def test_small_model_produces_estimate(self):
+        """Qwen2.5-0.5B on H100 should produce a valid estimated benchmark."""
+        results, warnings = self.finder._generate_estimated_configs(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            preferred_models=["Qwen/Qwen2.5-0.5B"],
+            existing_benchmarks=[],
+            gpu_types=["H100"],
+        )
+
+        # Filter out non-blocking warnings (e.g., DB persistence failures)
+        blocking_warnings = [w for w in warnings if "does not fit" in w or "Could not" in w]
+        assert not blocking_warnings, f"Unexpected blocking warnings: {blocking_warnings}"
+
+        assert len(results) >= 1, f"Expected >= 1 results, got {len(results)}. Warnings: {warnings}"
+
+        # All results should be valid estimated benchmarks
+        for bench in results:
+            assert bench.model_hf_repo == "Qwen/Qwen2.5-0.5B"
+            assert bench.hardware == "H100"
+            assert bench.estimated is True
+            assert bench.source == "llm-optimizer"
+            assert bench.confidence_level == "estimated"
+
+            # Roofline should produce positive performance values
+            assert bench.ttft_p95 is not None and bench.ttft_p95 > 0
+            assert bench.itl_p95 is not None and bench.itl_p95 > 0
+            assert bench.e2e_p95 is not None and bench.e2e_p95 > 0
+            assert bench.tps_p95 is not None and bench.tps_p95 > 0
+            assert bench.requests_per_second is not None and bench.requests_per_second > 0
+
+        # 0.5B model should fit at TP=1 on H100 (among other TPs)
+        tp_values = [r.hardware_count for r in results]
+        assert 1 in tp_values, f"Expected TP=1 among results, got TPs: {tp_values}"
+
+    def test_nonexistent_model_produces_warning(self):
+        """A model ID that doesn't exist on HuggingFace should warn, not crash."""
+        results, warnings = self.finder._generate_estimated_configs(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            preferred_models=["nonexistent-org/this-model-does-not-exist-12345"],
+            existing_benchmarks=[],
+            gpu_types=["H100"],
+        )
+
+        assert len(results) == 0
+        assert any("Could not estimate" in w for w in warnings)
+
+    def test_covered_model_is_skipped(self):
+        """A model already covered in existing_benchmarks should not be re-estimated."""
+        from planner.knowledge_base.benchmarks import BenchmarkData
+
+        existing = BenchmarkData(
+            {
+                "model_hf_repo": "Qwen/Qwen2.5-0.5B",
+                "hardware": "H100",
+                "hardware_count": 1,
+                "framework": "vllm",
+                "framework_version": "0.6.2",
+                "prompt_tokens": 512,
+                "output_tokens": 256,
+                "mean_input_tokens": 512,
+                "mean_output_tokens": 256,
+                "ttft_mean": 50,
+                "ttft_p90": 60,
+                "ttft_p95": 70,
+                "ttft_p99": 80,
+                "itl_mean": 5,
+                "itl_p90": 6,
+                "itl_p95": 7,
+                "itl_p99": 8,
+                "e2e_mean": 1000,
+                "e2e_p90": 1200,
+                "e2e_p95": 1400,
+                "e2e_p99": 1600,
+                "tps_mean": 100,
+                "tps_p90": 90,
+                "tps_p95": 85,
+                "tps_p99": 80,
+                "tokens_per_second": 100,
+                "requests_per_second": 10,
+                "source": "blis",
+                "confidence_level": "benchmarked",
+            }
+        )
+
+        results, warnings = self.finder._generate_estimated_configs(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            preferred_models=["Qwen/Qwen2.5-0.5B"],
+            existing_benchmarks=[existing],
+            gpu_types=["H100"],
+        )
+
+        # TP=1 is covered — it should not appear in results.
+        # Other TPs (2, 4, 8) may still be estimated.
+        tp_values = [r.hardware_count for r in results]
+        assert 1 not in tp_values, f"TP=1 should be skipped (already covered), got TPs: {tp_values}"

--- a/tests/unit/test_config_finder_cluster_gpus.py
+++ b/tests/unit/test_config_finder_cluster_gpus.py
@@ -51,7 +51,7 @@ class TestClusterGPUIntersection:
     def _call(self, cluster_gpu_types=None, preferred_gpu_types=None):
         """Helper to call plan_all_capacities and return gpu_types from the first repo call."""
         intent = _make_intent(preferred_gpu_types=preferred_gpu_types or [])
-        self.finder.plan_all_capacities(
+        _result, _warnings = self.finder.plan_all_capacities(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             intent=intent,
@@ -78,7 +78,7 @@ class TestClusterGPUIntersection:
     def test_empty_intersection_returns_no_configs(self):
         """Cluster has L4, user wants H100 -> empty intersection, early return."""
         intent = _make_intent(preferred_gpu_types=["H100"])
-        result = self.finder.plan_all_capacities(
+        result, _warnings = self.finder.plan_all_capacities(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             intent=intent,
@@ -121,7 +121,7 @@ class TestClusterGPUIntersection:
         # but we verify it retried without the filter.
         self.mock_repo.find_configurations_meeting_slo.side_effect = [[], []]
         intent = _make_intent()
-        self.finder.plan_all_capacities(
+        _result, _warnings = self.finder.plan_all_capacities(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             intent=intent,
@@ -138,7 +138,7 @@ class TestClusterGPUIntersection:
         """Cluster+user GPU intersection has no benchmarks -> no fallback (user chose)."""
         self.mock_repo.find_configurations_meeting_slo.return_value = []
         intent = _make_intent(preferred_gpu_types=["H100"])
-        result = self.finder.plan_all_capacities(
+        result, _warnings = self.finder.plan_all_capacities(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             intent=intent,

--- a/tests/unit/test_config_finder_cluster_gpus.py
+++ b/tests/unit/test_config_finder_cluster_gpus.py
@@ -134,16 +134,18 @@ class TestClusterGPUIntersection:
         # Second call: no GPU filter (fallback)
         assert calls[1].kwargs.get("gpu_types") is None
 
-    def test_cluster_gpu_no_benchmarks_no_fallback_when_user_pref(self):
-        """Cluster+user GPU intersection has no benchmarks -> no fallback (user chose)."""
+    def test_cluster_gpu_no_benchmarks_fallback_with_warning_when_user_pref(self):
+        """Cluster+user GPU intersection has no benchmarks -> fallback with warning."""
         self.mock_repo.find_configurations_meeting_slo.return_value = []
         intent = _make_intent(preferred_gpu_types=["H100"])
-        result, _warnings = self.finder.plan_all_capacities(
+        result, warnings = self.finder.plan_all_capacities(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             intent=intent,
             cluster_gpu_types=["H100", "L4"],
         )
         assert result == []
-        # Should only call once (no fallback since user expressed a GPU preference)
-        assert self.mock_repo.find_configurations_meeting_slo.call_count == 1
+        # Should call twice: first with preferred GPUs, then fallback without
+        assert self.mock_repo.find_configurations_meeting_slo.call_count == 2
+        # Should warn that preferred GPUs had no results
+        assert any("preferred GPUs" in w for w in warnings)

--- a/tests/unit/test_config_finder_quality_scorer.py
+++ b/tests/unit/test_config_finder_quality_scorer.py
@@ -118,7 +118,7 @@ def test_injected_scorer_used_in_plan_all_capacities():
         quality_scorer=mock_scorer,
     )
 
-    results = finder.plan_all_capacities(
+    results, _warnings = finder.plan_all_capacities(
         traffic_profile=_make_traffic(),
         slo_targets=_make_slo(),
         intent=_make_intent(),
@@ -158,7 +158,7 @@ def test_default_scorer_used_when_none_injected():
         "planner.recommendation.quality.score_model_quality",
         return_value=60.0,
     ) as mock_default:
-        results = finder.plan_all_capacities(
+        results, _warnings = finder.plan_all_capacities(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             intent=_make_intent(),
@@ -196,7 +196,7 @@ def test_injected_scorer_fallback_on_zero():
         quality_scorer=mock_scorer,
     )
 
-    results = finder.plan_all_capacities(
+    results, _warnings = finder.plan_all_capacities(
         traffic_profile=_make_traffic(),
         slo_targets=_make_slo(),
         intent=_make_intent(),

--- a/tests/unit/test_dependencies_source_selection.py
+++ b/tests/unit/test_dependencies_source_selection.py
@@ -90,17 +90,19 @@ def test_model_catalog_mode_creates_client_and_syncs():
 @pytest.mark.unit
 @patch.dict("os.environ", {"PLANNER_BENCHMARK_SOURCE": "postgresql"}, clear=False)
 def test_postgresql_workflow_uses_defaults():
-    """When source is postgresql, init_app_state() creates default RecommendationWorkflow."""
+    """When source is postgresql, init_app_state() creates RecommendationWorkflow with shared catalog."""
     app = _make_mock_app()
     with (
         patch("planner.api.dependencies.RecommendationWorkflow") as mock_wf_cls,
-        patch("planner.api.dependencies.ModelCatalog"),
+        patch("planner.api.dependencies.ModelCatalog") as mock_mc,
         patch("planner.api.dependencies.SLOTemplateRepository"),
         patch("planner.api.dependencies.DeploymentGenerator"),
         patch("planner.api.dependencies.YAMLValidator"),
+        patch("planner.recommendation.config_finder.ConfigFinder") as mock_cf_cls,
     ):
         deps.init_app_state(app)
-        mock_wf_cls.assert_called_once_with()
+        mock_cf_cls.assert_called_once_with(catalog=mock_mc.return_value)
+        mock_wf_cls.assert_called_once_with(config_finder=mock_cf_cls.return_value)
         assert app.state.workflow == mock_wf_cls.return_value
         assert app.state.model_catalog_client is None
 
@@ -116,6 +118,7 @@ def test_init_app_state_sets_all_singletons():
         patch("planner.api.dependencies.SLOTemplateRepository") as mock_slo,
         patch("planner.api.dependencies.DeploymentGenerator") as mock_dg,
         patch("planner.api.dependencies.YAMLValidator") as mock_yv,
+        patch("planner.recommendation.config_finder.ConfigFinder"),
     ):
         deps.init_app_state(app)
 

--- a/tests/unit/test_estimated_performance.py
+++ b/tests/unit/test_estimated_performance.py
@@ -1,0 +1,538 @@
+"""Unit tests for estimated performance flow (roofline estimation)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from planner.knowledge_base.benchmarks import BenchmarkData
+from planner.recommendation.config_finder import ConfigFinder
+from planner.shared.schemas import DeploymentIntent, SLOTargets, TrafficProfile
+
+
+def _make_intent(
+    preferred_gpu_types: list[str] | None = None,
+    preferred_models: list[str] | None = None,
+) -> DeploymentIntent:
+    """Create a minimal DeploymentIntent for testing."""
+    return DeploymentIntent(
+        use_case="chatbot_conversational",
+        experience_class="conversational",
+        user_count=100,
+        preferred_gpu_types=preferred_gpu_types or [],
+        preferred_models=preferred_models or [],
+        additional_context=None,
+    )
+
+
+def _make_traffic() -> TrafficProfile:
+    return TrafficProfile(
+        prompt_tokens=512,
+        output_tokens=256,
+        expected_qps=5.0,
+    )
+
+
+def _make_slo() -> SLOTargets:
+    return SLOTargets(
+        ttft_p95_target_ms=500,
+        itl_p95_target_ms=50,
+        e2e_p95_target_ms=15000,
+    )
+
+
+def _make_benchmark_data(
+    model: str = "meta-llama/Llama-3.1-8B-Instruct",
+    hardware: str = "H100",
+    hardware_count: int = 1,
+    source: str = "blis",
+    confidence_level: str = "benchmarked",
+) -> BenchmarkData:
+    """Create a BenchmarkData with default values."""
+    return BenchmarkData(
+        {
+            "model_hf_repo": model,
+            "hardware": hardware,
+            "hardware_count": hardware_count,
+            "framework": "vllm",
+            "framework_version": "0.6.2",
+            "prompt_tokens": 512,
+            "output_tokens": 256,
+            "mean_input_tokens": 512,
+            "mean_output_tokens": 256,
+            "ttft_mean": 100,
+            "ttft_p90": 120,
+            "ttft_p95": 130,
+            "ttft_p99": 150,
+            "itl_mean": 10,
+            "itl_p90": 12,
+            "itl_p95": 14,
+            "itl_p99": 18,
+            "e2e_mean": 3000,
+            "e2e_p90": 3500,
+            "e2e_p95": 4000,
+            "e2e_p99": 5000,
+            "tps_mean": 50.0,
+            "tps_p90": 45.0,
+            "tps_p95": 42.0,
+            "tps_p99": 38.0,
+            "tokens_per_second": 50.0,
+            "requests_per_second": 10.0,
+            "estimated": False,
+            "source": source,
+            "confidence_level": confidence_level,
+            "model_uri": None,
+        }
+    )
+
+
+@pytest.mark.unit
+class TestConvertEstimationToBenchmark:
+    """Test _convert_estimation_to_benchmark() static method."""
+
+    def test_basic_conversion(self):
+        bench = ConfigFinder._convert_estimation_to_benchmark(
+            model_id="meta-llama/Llama-3.3-70B-Instruct",
+            gpu_type="H100",
+            gpu_count=2,
+            prompt_tokens=512,
+            output_tokens=256,
+            ttft_ms=150.0,
+            itl_ms=20.0,
+            e2e_latency_ms=5000.0,
+            output_throughput_tps=80.0,
+        )
+
+        assert bench.model_hf_repo == "meta-llama/Llama-3.3-70B-Instruct"
+        assert bench.hardware == "H100"
+        assert bench.hardware_count == 2
+        assert bench.estimated is True
+        assert bench.source == "llm-optimizer"
+        assert bench.confidence_level == "estimated"
+        assert bench.framework == "vllm"
+        assert bench.framework_version == "estimated"
+
+    def test_same_value_all_percentiles(self):
+        bench = ConfigFinder._convert_estimation_to_benchmark(
+            model_id="test/model",
+            gpu_type="A100-80",
+            gpu_count=1,
+            prompt_tokens=512,
+            output_tokens=256,
+            ttft_ms=200.0,
+            itl_ms=25.0,
+            e2e_latency_ms=6000.0,
+            output_throughput_tps=100.0,
+        )
+
+        # Roofline produces single-point estimates — all percentiles identical
+        assert bench.ttft_mean == bench.ttft_p90 == bench.ttft_p95 == bench.ttft_p99 == 200.0
+        assert bench.itl_mean == bench.itl_p90 == bench.itl_p95 == bench.itl_p99 == 25.0
+        assert bench.e2e_mean == bench.e2e_p90 == bench.e2e_p95 == bench.e2e_p99 == 6000.0
+        assert bench.tps_mean == bench.tps_p90 == bench.tps_p95 == bench.tps_p99 == 100.0
+
+    def test_requests_per_second_calculation(self):
+        bench = ConfigFinder._convert_estimation_to_benchmark(
+            model_id="test/model",
+            gpu_type="H100",
+            gpu_count=1,
+            prompt_tokens=512,
+            output_tokens=256,
+            ttft_ms=100.0,
+            itl_ms=10.0,
+            e2e_latency_ms=3000.0,
+            output_throughput_tps=512.0,
+        )
+
+        # RPS = output_throughput_tps / output_tokens = 512 / 256 = 2.0
+        assert bench.requests_per_second == 2.0
+
+    def test_zero_output_tokens(self):
+        """RPS should be 0 when output_tokens is 0 (avoid division by zero)."""
+        bench = ConfigFinder._convert_estimation_to_benchmark(
+            model_id="test/model",
+            gpu_type="H100",
+            gpu_count=1,
+            prompt_tokens=512,
+            output_tokens=0,
+            ttft_ms=100.0,
+            itl_ms=10.0,
+            e2e_latency_ms=3000.0,
+            output_throughput_tps=50.0,
+        )
+
+        assert bench.requests_per_second == 0.0
+
+    def test_traffic_profile_fields(self):
+        bench = ConfigFinder._convert_estimation_to_benchmark(
+            model_id="test/model",
+            gpu_type="L40",
+            gpu_count=1,
+            prompt_tokens=1024,
+            output_tokens=512,
+            ttft_ms=200.0,
+            itl_ms=30.0,
+            e2e_latency_ms=8000.0,
+            output_throughput_tps=60.0,
+        )
+
+        assert bench.prompt_tokens == 1024
+        assert bench.output_tokens == 512
+        assert bench.mean_input_tokens == 1024
+        assert bench.mean_output_tokens == 512
+
+    def test_to_dict_round_trip(self):
+        """Converted benchmark should produce a valid dict via to_dict()."""
+        bench = ConfigFinder._convert_estimation_to_benchmark(
+            model_id="test/model",
+            gpu_type="H100",
+            gpu_count=1,
+            prompt_tokens=512,
+            output_tokens=256,
+            ttft_ms=100.0,
+            itl_ms=10.0,
+            e2e_latency_ms=3000.0,
+            output_throughput_tps=50.0,
+        )
+
+        d = bench.to_dict()
+        assert d["source"] == "llm-optimizer"
+        assert d["confidence_level"] == "estimated"
+        assert d["estimated"] is True
+        assert d["model_hf_repo"] == "test/model"
+
+
+@pytest.mark.unit
+class TestCatalogToRooflineGPUMapping:
+    """Test the _CATALOG_TO_ROOFLINE_GPU mapping."""
+
+    def test_h100_maps(self):
+        assert ConfigFinder._CATALOG_TO_ROOFLINE_GPU["H100"] == "H100"
+
+    def test_a100_80_maps_to_a100(self):
+        assert ConfigFinder._CATALOG_TO_ROOFLINE_GPU["A100-80"] == "A100"
+
+    def test_a100_40_maps(self):
+        assert ConfigFinder._CATALOG_TO_ROOFLINE_GPU["A100-40"] == "A100-40GB"
+
+    def test_unsupported_gpu_not_in_map(self):
+        assert "L4" not in ConfigFinder._CATALOG_TO_ROOFLINE_GPU
+        assert "A10G" not in ConfigFinder._CATALOG_TO_ROOFLINE_GPU
+        assert "MI300X" not in ConfigFinder._CATALOG_TO_ROOFLINE_GPU
+
+
+@pytest.mark.unit
+class TestGenerateEstimatedConfigs:
+    """Test _generate_estimated_configs() orchestration."""
+
+    def setup_method(self):
+        self.mock_repo = MagicMock()
+        self.mock_repo._get_connection.return_value = MagicMock()
+        self.mock_catalog = MagicMock()
+
+        # Set up GPU types in catalog
+        gpu_h100 = MagicMock()
+        gpu_h100.gpu_type = "H100"
+        gpu_h100.memory_gb = 80
+        gpu_a100 = MagicMock()
+        gpu_a100.gpu_type = "A100-80"
+        gpu_a100.memory_gb = 80
+        self.mock_catalog.get_all_gpu_types.return_value = [gpu_h100, gpu_a100]
+        self.mock_catalog.get_all_models.return_value = []
+
+        self.finder = ConfigFinder(
+            benchmark_repo=self.mock_repo,
+            catalog=self.mock_catalog,
+        )
+
+    @patch("planner.recommendation.config_finder.GPURecommender")
+    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
+    @patch("planner.recommendation.config_finder.check_model_fits_gpu")
+    def test_skips_covered_combinations(self, mock_fits, mock_config, mock_recommender_cls):
+        """Models already in existing_benchmarks at all valid TPs should be skipped."""
+        mock_config.return_value = MagicMock()
+        mock_fits.return_value = [1, 2]  # Model fits at TP=1 and TP=2
+
+        # Existing benchmarks cover both TP values
+        existing = [
+            _make_benchmark_data(
+                model="meta-llama/Llama-3.1-8B-Instruct", hardware="H100", hardware_count=1
+            ),
+            _make_benchmark_data(
+                model="meta-llama/Llama-3.1-8B-Instruct", hardware="H100", hardware_count=2
+            ),
+        ]
+
+        results, warnings = self.finder._generate_estimated_configs(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            preferred_models=["meta-llama/Llama-3.1-8B-Instruct"],
+            existing_benchmarks=existing,
+            gpu_types=["H100"],
+        )
+
+        # Both TP values are covered — no estimation should run
+        assert len(results) == 0
+        mock_recommender_cls.assert_not_called()
+
+    @patch("planner.recommendation.config_finder.GPURecommender")
+    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
+    @patch("planner.recommendation.config_finder.check_model_fits_gpu")
+    def test_generates_for_uncovered_model(self, mock_fits, mock_config, mock_recommender_cls):
+        """Uncovered model/GPU pairs should get roofline estimates."""
+        mock_config.return_value = MagicMock()
+        mock_fits.return_value = [2]  # Model fits at TP=2
+
+        # Set up mock GPURecommender
+        mock_result = MagicMock()
+        mock_best_latency = MagicMock()
+        mock_best_latency.ttft_ms = 200.0
+        mock_best_latency.itl_ms = 25.0
+        mock_best_latency.e2e_latency_s = 5.0
+        mock_best_latency.output_throughput_tps = 80.0
+        mock_result.best_configs = {"best_latency": mock_best_latency}
+
+        mock_recommender = MagicMock()
+        mock_recommender.get_gpu_results.return_value = (
+            {"H100": mock_result},
+            {},
+        )
+        mock_recommender_cls.return_value = mock_recommender
+
+        results, warnings = self.finder._generate_estimated_configs(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            preferred_models=["meta-llama/Llama-3.3-70B-Instruct"],
+            existing_benchmarks=[],
+            gpu_types=["H100"],
+        )
+
+        assert len(results) == 1
+        bench = results[0]
+        assert bench.model_hf_repo == "meta-llama/Llama-3.3-70B-Instruct"
+        assert bench.hardware == "H100"
+        assert bench.hardware_count == 2
+        assert bench.estimated is True
+        assert bench.source == "llm-optimizer"
+        assert bench.confidence_level == "estimated"
+        assert bench.ttft_p95 == 200.0
+        assert bench.e2e_p95 == 5000.0  # 5.0s * 1000
+
+    @patch("planner.recommendation.config_finder.GPURecommender")
+    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
+    @patch("planner.recommendation.config_finder.check_model_fits_gpu")
+    def test_generates_estimates_for_all_valid_tps(
+        self, mock_fits, mock_config, mock_recommender_cls
+    ):
+        """Should generate one estimate per valid TP value."""
+        mock_config.return_value = MagicMock()
+        mock_fits.return_value = [1, 2, 4]  # Model fits at TP=1, 2, and 4
+
+        # Set up mock GPURecommender to return results for each call
+        mock_result = MagicMock()
+        mock_best_latency = MagicMock()
+        mock_best_latency.ttft_ms = 200.0
+        mock_best_latency.itl_ms = 25.0
+        mock_best_latency.e2e_latency_s = 5.0
+        mock_best_latency.output_throughput_tps = 80.0
+        mock_result.best_configs = {"best_latency": mock_best_latency}
+
+        mock_recommender = MagicMock()
+        mock_recommender.get_gpu_results.return_value = (
+            {"H100": mock_result},
+            {},
+        )
+        mock_recommender_cls.return_value = mock_recommender
+
+        results, warnings = self.finder._generate_estimated_configs(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            preferred_models=["meta-llama/Llama-3.1-8B-Instruct"],
+            existing_benchmarks=[],
+            gpu_types=["H100"],
+        )
+
+        assert len(results) == 3
+        tp_values = sorted(r.hardware_count for r in results)
+        assert tp_values == [1, 2, 4]
+
+        # GPURecommender should have been called once per TP value
+        assert mock_recommender_cls.call_count == 3
+        # Verify max_gpus was set to each TP value
+        called_max_gpus = sorted(
+            call.kwargs.get("max_gpus", call.args[3] if len(call.args) > 3 else None)
+            for call in mock_recommender_cls.call_args_list
+        )
+        assert called_max_gpus == [1, 2, 4]
+
+    @patch("planner.recommendation.config_finder.GPURecommender")
+    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
+    @patch("planner.recommendation.config_finder.check_model_fits_gpu")
+    def test_skips_covered_tp_estimates_uncovered(
+        self, mock_fits, mock_config, mock_recommender_cls
+    ):
+        """Should only estimate uncovered TP values when some are already in benchmarks."""
+        mock_config.return_value = MagicMock()
+        mock_fits.return_value = [1, 2]  # Model fits at TP=1 and TP=2
+
+        # TP=1 already covered
+        existing = [
+            _make_benchmark_data(
+                model="meta-llama/Llama-3.1-8B-Instruct", hardware="H100", hardware_count=1
+            ),
+        ]
+
+        mock_result = MagicMock()
+        mock_best_latency = MagicMock()
+        mock_best_latency.ttft_ms = 150.0
+        mock_best_latency.itl_ms = 20.0
+        mock_best_latency.e2e_latency_s = 4.0
+        mock_best_latency.output_throughput_tps = 100.0
+        mock_result.best_configs = {"best_latency": mock_best_latency}
+
+        mock_recommender = MagicMock()
+        mock_recommender.get_gpu_results.return_value = (
+            {"H100": mock_result},
+            {},
+        )
+        mock_recommender_cls.return_value = mock_recommender
+
+        results, warnings = self.finder._generate_estimated_configs(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            preferred_models=["meta-llama/Llama-3.1-8B-Instruct"],
+            existing_benchmarks=existing,
+            gpu_types=["H100"],
+        )
+
+        # Only TP=2 should be estimated (TP=1 is covered)
+        assert len(results) == 1
+        assert results[0].hardware_count == 2
+
+    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
+    @patch("planner.recommendation.config_finder.check_model_fits_gpu")
+    def test_model_fits_no_gpu_warning(self, mock_fits, mock_config):
+        """Model that fits no GPUs should produce a warning."""
+        mock_config.return_value = MagicMock()
+        mock_fits.return_value = []  # Model doesn't fit
+
+        results, warnings = self.finder._generate_estimated_configs(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            preferred_models=["huge/model-that-doesnt-fit"],
+            existing_benchmarks=[],
+            gpu_types=["H100"],
+        )
+
+        assert len(results) == 0
+        assert any("does not fit" in w for w in warnings)
+
+    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
+    def test_hf_unreachable_warning(self, mock_config):
+        """HuggingFace API failure should produce a warning."""
+        mock_config.side_effect = Exception("Connection refused")
+
+        results, warnings = self.finder._generate_estimated_configs(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            preferred_models=["nonexistent/model"],
+            existing_benchmarks=[],
+            gpu_types=["H100"],
+        )
+
+        assert len(results) == 0
+        assert any("Could not estimate" in w for w in warnings)
+
+    def test_no_models_returns_empty(self):
+        """Empty preferred_models should return immediately."""
+        results, warnings = self.finder._generate_estimated_configs(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            preferred_models=[],
+            existing_benchmarks=[],
+            gpu_types=None,
+        )
+
+        assert results == []
+        assert warnings == []
+
+
+@pytest.mark.unit
+class TestPlanAllCapacitiesEstimated:
+    """Test that plan_all_capacities passes estimated params correctly."""
+
+    def setup_method(self):
+        self.mock_repo = MagicMock()
+        self.mock_repo.find_configurations_meeting_slo.return_value = []
+        self.mock_catalog = MagicMock()
+        self.mock_catalog.get_all_models.return_value = []
+        self.finder = ConfigFinder(benchmark_repo=self.mock_repo, catalog=self.mock_catalog)
+
+    @patch.object(ConfigFinder, "_generate_estimated_configs")
+    def test_calls_estimated_flow_when_enabled(self, mock_gen):
+        """Should call _generate_estimated_configs when enable_estimated=True and preferred_models set."""
+        mock_gen.return_value = ([], [])
+
+        self.finder.plan_all_capacities(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            intent=_make_intent(preferred_models=["test/model"]),
+            preferred_models=["test/model"],
+            enable_estimated=True,
+        )
+
+        mock_gen.assert_called_once()
+
+    @patch.object(ConfigFinder, "_generate_estimated_configs")
+    def test_skips_estimated_flow_when_disabled(self, mock_gen):
+        """Should not call _generate_estimated_configs when enable_estimated=False."""
+        mock_gen.return_value = ([], [])
+
+        self.finder.plan_all_capacities(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            intent=_make_intent(preferred_models=["test/model"]),
+            preferred_models=["test/model"],
+            enable_estimated=False,
+        )
+
+        mock_gen.assert_not_called()
+
+    @patch.object(ConfigFinder, "_generate_estimated_configs")
+    def test_skips_estimated_flow_without_models(self, mock_gen):
+        """Should not call _generate_estimated_configs when no preferred_models."""
+        mock_gen.return_value = ([], [])
+
+        self.finder.plan_all_capacities(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            intent=_make_intent(),
+            enable_estimated=True,
+        )
+
+        mock_gen.assert_not_called()
+
+    @patch.object(ConfigFinder, "_generate_estimated_configs")
+    def test_benchmark_metrics_include_confidence_level(self, mock_gen):
+        """benchmark_metrics dict should include source and confidence_level."""
+        # Return a benchmark from the DB query
+        bench = _make_benchmark_data(source="blis", confidence_level="benchmarked")
+        self.mock_repo.find_configurations_meeting_slo.return_value = [bench]
+
+        mock_gpu_cost = MagicMock(return_value=4.0)
+        self.mock_catalog.calculate_gpu_cost = mock_gpu_cost
+
+        mock_gen.return_value = ([], [])
+
+        results, _warnings = self.finder.plan_all_capacities(
+            traffic_profile=_make_traffic(),
+            slo_targets=_make_slo(),
+            intent=_make_intent(),
+            enable_estimated=True,
+        )
+
+        assert len(results) == 1
+        metrics = results[0].benchmark_metrics
+        assert metrics is not None
+        assert metrics["source"] == "blis"
+        assert metrics["confidence_level"] == "benchmarked"
+        assert metrics["estimated"] is False

--- a/tests/unit/test_estimated_performance.py
+++ b/tests/unit/test_estimated_performance.py
@@ -6,6 +6,11 @@ import pytest
 
 from planner.knowledge_base.benchmarks import BenchmarkData
 from planner.recommendation.config_finder import ConfigFinder
+from planner.recommendation.estimator import (
+    CATALOG_TO_ROOFLINE_GPU,
+    convert_estimation_to_benchmark,
+    generate_estimated_configs,
+)
 from planner.shared.schemas import DeploymentIntent, SLOTargets, TrafficProfile
 
 
@@ -87,10 +92,10 @@ def _make_benchmark_data(
 
 @pytest.mark.unit
 class TestConvertEstimationToBenchmark:
-    """Test _convert_estimation_to_benchmark() static method."""
+    """Test convert_estimation_to_benchmark() function."""
 
     def test_basic_conversion(self):
-        bench = ConfigFinder._convert_estimation_to_benchmark(
+        bench = convert_estimation_to_benchmark(
             model_id="meta-llama/Llama-3.3-70B-Instruct",
             gpu_type="H100",
             gpu_count=2,
@@ -112,7 +117,7 @@ class TestConvertEstimationToBenchmark:
         assert bench.framework_version == "estimated"
 
     def test_same_value_all_percentiles(self):
-        bench = ConfigFinder._convert_estimation_to_benchmark(
+        bench = convert_estimation_to_benchmark(
             model_id="test/model",
             gpu_type="A100-80",
             gpu_count=1,
@@ -131,7 +136,7 @@ class TestConvertEstimationToBenchmark:
         assert bench.tps_mean == bench.tps_p90 == bench.tps_p95 == bench.tps_p99 == 100.0
 
     def test_requests_per_second_calculation(self):
-        bench = ConfigFinder._convert_estimation_to_benchmark(
+        bench = convert_estimation_to_benchmark(
             model_id="test/model",
             gpu_type="H100",
             gpu_count=1,
@@ -148,7 +153,7 @@ class TestConvertEstimationToBenchmark:
 
     def test_zero_output_tokens(self):
         """RPS should be 0 when output_tokens is 0 (avoid division by zero)."""
-        bench = ConfigFinder._convert_estimation_to_benchmark(
+        bench = convert_estimation_to_benchmark(
             model_id="test/model",
             gpu_type="H100",
             gpu_count=1,
@@ -163,7 +168,7 @@ class TestConvertEstimationToBenchmark:
         assert bench.requests_per_second == 0.0
 
     def test_traffic_profile_fields(self):
-        bench = ConfigFinder._convert_estimation_to_benchmark(
+        bench = convert_estimation_to_benchmark(
             model_id="test/model",
             gpu_type="L40",
             gpu_count=1,
@@ -182,7 +187,7 @@ class TestConvertEstimationToBenchmark:
 
     def test_to_dict_round_trip(self):
         """Converted benchmark should produce a valid dict via to_dict()."""
-        bench = ConfigFinder._convert_estimation_to_benchmark(
+        bench = convert_estimation_to_benchmark(
             model_id="test/model",
             gpu_type="H100",
             gpu_count=1,
@@ -203,26 +208,26 @@ class TestConvertEstimationToBenchmark:
 
 @pytest.mark.unit
 class TestCatalogToRooflineGPUMapping:
-    """Test the _CATALOG_TO_ROOFLINE_GPU mapping."""
+    """Test the CATALOG_TO_ROOFLINE_GPU mapping."""
 
     def test_h100_maps(self):
-        assert ConfigFinder._CATALOG_TO_ROOFLINE_GPU["H100"] == "H100"
+        assert CATALOG_TO_ROOFLINE_GPU["H100"] == "H100"
 
     def test_a100_80_maps_to_a100(self):
-        assert ConfigFinder._CATALOG_TO_ROOFLINE_GPU["A100-80"] == "A100"
+        assert CATALOG_TO_ROOFLINE_GPU["A100-80"] == "A100"
 
     def test_a100_40_maps(self):
-        assert ConfigFinder._CATALOG_TO_ROOFLINE_GPU["A100-40"] == "A100-40GB"
+        assert CATALOG_TO_ROOFLINE_GPU["A100-40"] == "A100-40GB"
 
     def test_unsupported_gpu_not_in_map(self):
-        assert "L4" not in ConfigFinder._CATALOG_TO_ROOFLINE_GPU
-        assert "A10G" not in ConfigFinder._CATALOG_TO_ROOFLINE_GPU
-        assert "MI300X" not in ConfigFinder._CATALOG_TO_ROOFLINE_GPU
+        assert "L4" not in CATALOG_TO_ROOFLINE_GPU
+        assert "A10G" not in CATALOG_TO_ROOFLINE_GPU
+        assert "MI300X" not in CATALOG_TO_ROOFLINE_GPU
 
 
 @pytest.mark.unit
 class TestGenerateEstimatedConfigs:
-    """Test _generate_estimated_configs() orchestration."""
+    """Test generate_estimated_configs() orchestration."""
 
     def setup_method(self):
         self.mock_repo = MagicMock()
@@ -244,9 +249,9 @@ class TestGenerateEstimatedConfigs:
             catalog=self.mock_catalog,
         )
 
-    @patch("planner.recommendation.config_finder.GPURecommender")
-    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
-    @patch("planner.recommendation.config_finder.check_model_fits_gpu")
+    @patch("planner.recommendation.estimator.GPURecommender")
+    @patch("planner.recommendation.estimator.get_model_config_from_hf")
+    @patch("planner.recommendation.estimator.check_model_fits_gpu")
     def test_skips_covered_combinations(self, mock_fits, mock_config, mock_recommender_cls):
         """Models already in existing_benchmarks at all valid TPs should be skipped."""
         mock_config.return_value = MagicMock()
@@ -262,21 +267,23 @@ class TestGenerateEstimatedConfigs:
             ),
         ]
 
-        results, warnings = self.finder._generate_estimated_configs(
+        results, warnings = generate_estimated_configs(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             preferred_models=["meta-llama/Llama-3.1-8B-Instruct"],
             existing_benchmarks=existing,
             gpu_types=["H100"],
+            catalog=self.mock_catalog,
+            benchmark_repo=self.mock_repo,
         )
 
         # Both TP values are covered — no estimation should run
         assert len(results) == 0
         mock_recommender_cls.assert_not_called()
 
-    @patch("planner.recommendation.config_finder.GPURecommender")
-    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
-    @patch("planner.recommendation.config_finder.check_model_fits_gpu")
+    @patch("planner.recommendation.estimator.GPURecommender")
+    @patch("planner.recommendation.estimator.get_model_config_from_hf")
+    @patch("planner.recommendation.estimator.check_model_fits_gpu")
     def test_generates_for_uncovered_model(self, mock_fits, mock_config, mock_recommender_cls):
         """Uncovered model/GPU pairs should get roofline estimates."""
         mock_config.return_value = MagicMock()
@@ -298,12 +305,14 @@ class TestGenerateEstimatedConfigs:
         )
         mock_recommender_cls.return_value = mock_recommender
 
-        results, warnings = self.finder._generate_estimated_configs(
+        results, warnings = generate_estimated_configs(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             preferred_models=["meta-llama/Llama-3.3-70B-Instruct"],
             existing_benchmarks=[],
             gpu_types=["H100"],
+            catalog=self.mock_catalog,
+            benchmark_repo=self.mock_repo,
         )
 
         assert len(results) == 1
@@ -317,9 +326,9 @@ class TestGenerateEstimatedConfigs:
         assert bench.ttft_p95 == 200.0
         assert bench.e2e_p95 == 5000.0  # 5.0s * 1000
 
-    @patch("planner.recommendation.config_finder.GPURecommender")
-    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
-    @patch("planner.recommendation.config_finder.check_model_fits_gpu")
+    @patch("planner.recommendation.estimator.GPURecommender")
+    @patch("planner.recommendation.estimator.get_model_config_from_hf")
+    @patch("planner.recommendation.estimator.check_model_fits_gpu")
     def test_generates_estimates_for_all_valid_tps(
         self, mock_fits, mock_config, mock_recommender_cls
     ):
@@ -343,12 +352,14 @@ class TestGenerateEstimatedConfigs:
         )
         mock_recommender_cls.return_value = mock_recommender
 
-        results, warnings = self.finder._generate_estimated_configs(
+        results, warnings = generate_estimated_configs(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             preferred_models=["meta-llama/Llama-3.1-8B-Instruct"],
             existing_benchmarks=[],
             gpu_types=["H100"],
+            catalog=self.mock_catalog,
+            benchmark_repo=self.mock_repo,
         )
 
         assert len(results) == 3
@@ -364,9 +375,9 @@ class TestGenerateEstimatedConfigs:
         )
         assert called_max_gpus == [1, 2, 4]
 
-    @patch("planner.recommendation.config_finder.GPURecommender")
-    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
-    @patch("planner.recommendation.config_finder.check_model_fits_gpu")
+    @patch("planner.recommendation.estimator.GPURecommender")
+    @patch("planner.recommendation.estimator.get_model_config_from_hf")
+    @patch("planner.recommendation.estimator.check_model_fits_gpu")
     def test_skips_covered_tp_estimates_uncovered(
         self, mock_fits, mock_config, mock_recommender_cls
     ):
@@ -396,47 +407,53 @@ class TestGenerateEstimatedConfigs:
         )
         mock_recommender_cls.return_value = mock_recommender
 
-        results, warnings = self.finder._generate_estimated_configs(
+        results, warnings = generate_estimated_configs(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             preferred_models=["meta-llama/Llama-3.1-8B-Instruct"],
             existing_benchmarks=existing,
             gpu_types=["H100"],
+            catalog=self.mock_catalog,
+            benchmark_repo=self.mock_repo,
         )
 
         # Only TP=2 should be estimated (TP=1 is covered)
         assert len(results) == 1
         assert results[0].hardware_count == 2
 
-    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
-    @patch("planner.recommendation.config_finder.check_model_fits_gpu")
+    @patch("planner.recommendation.estimator.get_model_config_from_hf")
+    @patch("planner.recommendation.estimator.check_model_fits_gpu")
     def test_model_fits_no_gpu_warning(self, mock_fits, mock_config):
         """Model that fits no GPUs should produce a warning."""
         mock_config.return_value = MagicMock()
         mock_fits.return_value = []  # Model doesn't fit
 
-        results, warnings = self.finder._generate_estimated_configs(
+        results, warnings = generate_estimated_configs(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             preferred_models=["huge/model-that-doesnt-fit"],
             existing_benchmarks=[],
             gpu_types=["H100"],
+            catalog=self.mock_catalog,
+            benchmark_repo=self.mock_repo,
         )
 
         assert len(results) == 0
         assert any("does not fit" in w for w in warnings)
 
-    @patch("planner.recommendation.config_finder.get_model_config_from_hf")
+    @patch("planner.recommendation.estimator.get_model_config_from_hf")
     def test_hf_unreachable_warning(self, mock_config):
         """HuggingFace API failure should produce a warning."""
         mock_config.side_effect = Exception("Connection refused")
 
-        results, warnings = self.finder._generate_estimated_configs(
+        results, warnings = generate_estimated_configs(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             preferred_models=["nonexistent/model"],
             existing_benchmarks=[],
             gpu_types=["H100"],
+            catalog=self.mock_catalog,
+            benchmark_repo=self.mock_repo,
         )
 
         assert len(results) == 0
@@ -444,12 +461,14 @@ class TestGenerateEstimatedConfigs:
 
     def test_no_models_returns_empty(self):
         """Empty preferred_models should return immediately."""
-        results, warnings = self.finder._generate_estimated_configs(
+        results, warnings = generate_estimated_configs(
             traffic_profile=_make_traffic(),
             slo_targets=_make_slo(),
             preferred_models=[],
             existing_benchmarks=[],
             gpu_types=None,
+            catalog=self.mock_catalog,
+            benchmark_repo=self.mock_repo,
         )
 
         assert results == []
@@ -467,9 +486,9 @@ class TestPlanAllCapacitiesEstimated:
         self.mock_catalog.get_all_models.return_value = []
         self.finder = ConfigFinder(benchmark_repo=self.mock_repo, catalog=self.mock_catalog)
 
-    @patch.object(ConfigFinder, "_generate_estimated_configs")
+    @patch("planner.recommendation.config_finder.generate_estimated_configs")
     def test_calls_estimated_flow_when_enabled(self, mock_gen):
-        """Should call _generate_estimated_configs when enable_estimated=True and preferred_models set."""
+        """Should call generate_estimated_configs when enable_estimated=True and preferred_models set."""
         mock_gen.return_value = ([], [])
 
         self.finder.plan_all_capacities(
@@ -482,9 +501,9 @@ class TestPlanAllCapacitiesEstimated:
 
         mock_gen.assert_called_once()
 
-    @patch.object(ConfigFinder, "_generate_estimated_configs")
+    @patch("planner.recommendation.config_finder.generate_estimated_configs")
     def test_skips_estimated_flow_when_disabled(self, mock_gen):
-        """Should not call _generate_estimated_configs when enable_estimated=False."""
+        """Should not call generate_estimated_configs when enable_estimated=False."""
         mock_gen.return_value = ([], [])
 
         self.finder.plan_all_capacities(
@@ -497,9 +516,9 @@ class TestPlanAllCapacitiesEstimated:
 
         mock_gen.assert_not_called()
 
-    @patch.object(ConfigFinder, "_generate_estimated_configs")
+    @patch("planner.recommendation.config_finder.generate_estimated_configs")
     def test_skips_estimated_flow_without_models(self, mock_gen):
-        """Should not call _generate_estimated_configs when no preferred_models."""
+        """Should not call generate_estimated_configs when no preferred_models."""
         mock_gen.return_value = ([], [])
 
         self.finder.plan_all_capacities(
@@ -511,7 +530,7 @@ class TestPlanAllCapacitiesEstimated:
 
         mock_gen.assert_not_called()
 
-    @patch.object(ConfigFinder, "_generate_estimated_configs")
+    @patch("planner.recommendation.config_finder.generate_estimated_configs")
     def test_benchmark_metrics_include_confidence_level(self, mock_gen):
         """benchmark_metrics dict should include source and confidence_level."""
         # Return a benchmark from the DB query

--- a/tests/unit/test_save_benchmarks.py
+++ b/tests/unit/test_save_benchmarks.py
@@ -1,0 +1,157 @@
+"""Unit tests for BenchmarkRepository.save_benchmarks()."""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from planner.knowledge_base.benchmarks import BenchmarkData, BenchmarkRepository
+
+
+def _make_benchmark(
+    model: str = "test/model",
+    hardware: str = "H100",
+    prompt_tokens: int = 512,
+    output_tokens: int = 256,
+) -> BenchmarkData:
+    """Create a minimal BenchmarkData for testing."""
+    return BenchmarkData(
+        {
+            "model_hf_repo": model,
+            "hardware": hardware,
+            "hardware_count": 1,
+            "framework": "vllm",
+            "framework_version": "0.6.2",
+            "prompt_tokens": prompt_tokens,
+            "output_tokens": output_tokens,
+            "mean_input_tokens": prompt_tokens,
+            "mean_output_tokens": output_tokens,
+            "ttft_mean": 100,
+            "ttft_p90": 120,
+            "ttft_p95": 130,
+            "ttft_p99": 150,
+            "itl_mean": 10,
+            "itl_p90": 12,
+            "itl_p95": 14,
+            "itl_p99": 18,
+            "e2e_mean": 3000,
+            "e2e_p90": 3500,
+            "e2e_p95": 4000,
+            "e2e_p99": 5000,
+            "tps_mean": 50.0,
+            "tps_p90": 45.0,
+            "tps_p95": 42.0,
+            "tps_p99": 38.0,
+            "tokens_per_second": 50.0,
+            "requests_per_second": 10.0,
+        }
+    )
+
+
+@pytest.fixture
+def repo():
+    """Create a BenchmarkRepository with mocked DB connection."""
+    with patch.object(BenchmarkRepository, "_test_connection"):
+        return BenchmarkRepository(database_url="postgresql://fake")
+
+
+@pytest.mark.unit
+class TestSaveBenchmarksRollback:
+    """A6: save_benchmarks() rolls back on insert failure."""
+
+    @patch("planner.knowledge_base.benchmarks.insert_benchmarks")
+    def test_rollback_called_on_insert_failure(self, mock_insert, repo):
+        """Connection should be rolled back when insert_benchmarks raises."""
+        mock_conn = MagicMock()
+        with patch.object(repo, "_get_connection", return_value=mock_conn):
+            mock_insert.side_effect = RuntimeError("DB write failed")
+
+            with pytest.raises(RuntimeError, match="DB write failed"):
+                repo.save_benchmarks([_make_benchmark()])
+
+            mock_conn.rollback.assert_called_once()
+            mock_conn.close.assert_called_once()
+
+    @patch("planner.knowledge_base.benchmarks.insert_benchmarks")
+    def test_no_rollback_on_success(self, mock_insert, repo):
+        """Connection should NOT be rolled back on successful insert."""
+        mock_conn = MagicMock()
+        with patch.object(repo, "_get_connection", return_value=mock_conn):
+            repo.save_benchmarks([_make_benchmark()])
+
+            mock_conn.rollback.assert_not_called()
+            mock_conn.close.assert_called_once()
+
+    @patch("planner.knowledge_base.benchmarks.insert_benchmarks")
+    def test_connection_closed_even_on_failure(self, mock_insert, repo):
+        """Connection must always be closed, even after rollback."""
+        mock_conn = MagicMock()
+        with patch.object(repo, "_get_connection", return_value=mock_conn):
+            mock_insert.side_effect = Exception("unexpected")
+
+            with pytest.raises(Exception, match="unexpected"):
+                repo.save_benchmarks([_make_benchmark()])
+
+            mock_conn.close.assert_called_once()
+
+
+@pytest.mark.unit
+class TestSaveBenchmarksValidationBeforeConnection:
+    """A5: Data preparation happens before DB connection is opened."""
+
+    @patch("planner.knowledge_base.benchmarks.insert_benchmarks")
+    def test_to_dict_failure_does_not_open_connection(self, mock_insert, repo):
+        """If to_dict() raises, _get_connection() should never be called."""
+        bad_bench = MagicMock(spec=BenchmarkData)
+        bad_bench.to_dict.side_effect = AttributeError("broken")
+
+        with patch.object(repo, "_get_connection") as mock_get_conn:
+            with pytest.raises(AttributeError, match="broken"):
+                repo.save_benchmarks([bad_bench])
+
+            mock_get_conn.assert_not_called()
+            mock_insert.assert_not_called()
+
+    @patch("planner.knowledge_base.benchmarks.insert_benchmarks")
+    def test_data_prepared_before_connection(self, mock_insert, repo):
+        """Verify insert receives prepared dicts with prompt_tokens/output_tokens filled."""
+        bench = _make_benchmark(prompt_tokens=1024, output_tokens=512)
+        mock_conn = MagicMock()
+
+        with patch.object(repo, "_get_connection", return_value=mock_conn):
+            repo.save_benchmarks([bench], source="test-src", confidence_level="benchmarked")
+
+        # insert_benchmarks should have been called with prepared dicts
+        mock_insert.assert_called_once()
+        args = mock_insert.call_args
+        benchmark_dicts = args[0][1]  # second positional arg
+        assert len(benchmark_dicts) == 1
+        assert benchmark_dicts[0]["prompt_tokens"] == 1024
+        assert benchmark_dicts[0]["output_tokens"] == 512
+        assert args[1]["source"] == "test-src"
+        assert args[1]["confidence_level"] == "benchmarked"
+
+    @patch("planner.knowledge_base.benchmarks.insert_benchmarks")
+    def test_setdefault_fills_missing_prompt_output_tokens(self, mock_insert, repo):
+        """setdefault should fill prompt_tokens/output_tokens from mean_input/output_tokens."""
+        bench = _make_benchmark()
+        # Simulate a dict where prompt_tokens/output_tokens are missing
+        original_to_dict = bench.to_dict
+
+        def to_dict_without_tokens():
+            d = original_to_dict()
+            del d["prompt_tokens"]
+            del d["output_tokens"]
+            return d
+
+        mock_conn = MagicMock()
+
+        with (
+            patch.object(bench, "to_dict", to_dict_without_tokens),
+            patch.object(repo, "_get_connection", return_value=mock_conn),
+        ):
+            repo.save_benchmarks([bench])
+
+        benchmark_dicts = mock_insert.call_args[0][1]
+        # Should have been filled from mean_input_tokens / mean_output_tokens
+        assert benchmark_dicts[0]["prompt_tokens"] == 512
+        assert benchmark_dicts[0]["output_tokens"] == 256

--- a/tests/unit/test_workflow_gpu_detection.py
+++ b/tests/unit/test_workflow_gpu_detection.py
@@ -42,7 +42,7 @@ class TestWorkflowGPUDetection:
         self, mock_config_finder, mock_detect
     ):
         mock_finder = mock_config_finder.return_value
-        mock_finder.plan_all_capacities.return_value = []
+        mock_finder.plan_all_capacities.return_value = ([], [])
 
         from planner.orchestration.workflow import RecommendationWorkflow
 
@@ -72,7 +72,7 @@ class TestWorkflowGPUDetection:
 
         mock_finder = mock_config_finder.return_value
         # Return a list with at least one config to avoid early return path
-        mock_finder.plan_all_capacities.return_value = [MagicMock()]
+        mock_finder.plan_all_capacities.return_value = ([MagicMock()], [])
 
         # Mock Analyzer to avoid complex schema validation
         mock_analyzer = mock_analyzer_cls.return_value
@@ -110,7 +110,7 @@ class TestWorkflowGPUDetection:
     @patch("planner.orchestration.workflow.ConfigFinder")
     def test_generate_ranked_from_spec_calls_detector(self, mock_config_finder, mock_detect):
         mock_finder = mock_config_finder.return_value
-        mock_finder.plan_all_capacities.return_value = []
+        mock_finder.plan_all_capacities.return_value = ([], [])
 
         from planner.orchestration.workflow import RecommendationWorkflow
 
@@ -125,7 +125,7 @@ class TestWorkflowGPUDetection:
     @patch("planner.orchestration.workflow.ConfigFinder")
     def test_empty_detection_passes_empty_list(self, mock_config_finder, mock_detect):
         mock_finder = mock_config_finder.return_value
-        mock_finder.plan_all_capacities.return_value = []
+        mock_finder.plan_all_capacities.return_value = ([], [])
 
         from planner.orchestration.workflow import RecommendationWorkflow
 

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -147,6 +147,22 @@ def fetch_priority_weights() -> dict | None:
 
 
 @st.cache_data(ttl=3600)
+def fetch_catalog_model_ids() -> list[str]:
+    """Fetch model IDs from the model catalog API.
+
+    Returns sorted list of model_id strings (e.g., "meta-llama/Llama-3.1-8B-Instruct").
+    """
+    try:
+        response = requests.get(f"{API_BASE_URL}/api/v1/models", timeout=DEFAULT_TIMEOUT)
+        response.raise_for_status()
+        data = response.json()
+        return sorted(m["model_id"] for m in data.get("models", []) if m.get("model_id"))
+    except Exception as e:
+        logger.warning(f"Failed to fetch catalog models: {e}")
+        return []
+
+
+@st.cache_data(ttl=3600)
 def fetch_gpu_types() -> dict[str, dict]:
     """Fetch all GPU types from the API, keyed by canonical gpu_type name.
 
@@ -323,6 +339,8 @@ def fetch_ranked_recommendations(
     include_near_miss: bool = False,
     percentile: str = "p95",
     preferred_gpu_types: list[str] | None = None,
+    preferred_models: list[str] | None = None,
+    enable_estimated: bool = True,
 ) -> dict | None:
     """Fetch ranked recommendations from the backend API.
 
@@ -339,12 +357,13 @@ def fetch_ranked_recommendations(
         include_near_miss: Whether to include near-SLO configurations
         percentile: Which percentile to use for SLO comparison (mean, p90, p95, p99)
         preferred_gpu_types: Optional list of GPU types to filter by (empty = any GPU)
+        preferred_models: Optional list of HuggingFace model IDs to include via estimation
+        enable_estimated: Whether to run roofline estimation for missing benchmarks
 
     Returns:
         RankedRecommendationsResponse as dict, or None on error
     """
     # Build request payload
-    # min_accuracy=35 filters out models with 30% fallback (no AA data)
     payload = {
         "use_case": use_case,
         "user_count": user_count,
@@ -356,8 +375,9 @@ def fetch_ranked_recommendations(
         "e2e_target_ms": e2e_target_ms,
         "percentile": percentile,
         "include_near_miss": include_near_miss,
-        "min_accuracy": 35,
         "preferred_gpu_types": preferred_gpu_types or [],
+        "preferred_models": preferred_models or [],
+        "enable_estimated": enable_estimated,
     }
 
     if weights:
@@ -367,7 +387,7 @@ def fetch_ranked_recommendations(
         response = requests.post(
             f"{API_BASE_URL}/api/v1/ranked-recommend-from-spec",
             json=payload,
-            timeout=30,
+            timeout=90,  # Backend estimation timeout (60s default) + buffer
         )
         response.raise_for_status()
         return cast(dict[Any, Any], response.json())

--- a/ui/app.py
+++ b/ui/app.py
@@ -226,6 +226,7 @@ def render_use_case_input_tab(priority: str, models_df: pd.DataFrame):
                 "custom_e2e",
                 "custom_qps",
                 "used_priority",
+                "_last_spec_fingerprint",
             ]:
                 if key in st.session_state:
                     del st.session_state[key]
@@ -243,6 +244,7 @@ def render_use_case_input_tab(priority: str, models_df: pd.DataFrame):
         st.session_state.slo_approved = None
         st.session_state.recommendation_result = None
         st.session_state.edited_extraction = None
+        st.session_state.pop("_last_spec_fingerprint", None)
         # Clear previous recommendation selection and deployment state
         st.session_state.deployment_selected_config = None
         st.session_state.deployment_selected_category = None
@@ -266,6 +268,7 @@ def render_use_case_input_tab(priority: str, models_df: pd.DataFrame):
                 st.session_state.slo_approved = None
                 st.session_state.edited_extraction = None
                 st.session_state.ranked_response = None
+                st.session_state.pop("_last_spec_fingerprint", None)
 
                 for key in [
                     "accuracy_priority",
@@ -376,10 +379,14 @@ def render_technical_specs_tab():
     render_slo_with_approval(final_extraction)
 
     if st.session_state.slo_approved is True:
+        if st.session_state.recommendation_result is not None:
+            status_msg = "<strong>Step 2 Complete</strong> · You can now view Recommendations"
+        else:
+            status_msg = "<strong>Step 2 Complete</strong> · Generating recommendations…"
         st.markdown(
-            """
+            f"""
         <div style="padding: 0.75rem 1rem; border-radius: 8px; font-size: 1rem; margin-bottom: 0.75rem; max-width: 50%;">
-            <strong>Step 2 Complete</strong> · You can now view Recommendations
+            {status_msg}
         </div>
         """,
             unsafe_allow_html=True,
@@ -418,10 +425,6 @@ def render_results_tab(priority: str, models_df: pd.DataFrame):
         st.session_state.edited_extraction or st.session_state.extraction_result or {}
     )
 
-    # Always regenerate recommendations to ensure fresh SLO filtering
-    st.session_state.recommendation_result = None
-    st.session_state.pop("ranked_response", None)
-
     # Get all specification values from session state
     use_case = final_extraction.get("use_case", "chatbot_conversational")
     user_count = final_extraction.get("user_count", 1000)
@@ -447,27 +450,56 @@ def render_results_tab(priority: str, models_df: pd.DataFrame):
     }
 
     preferred_gpu_types = final_extraction.get("preferred_gpu_types", [])
+    preferred_models = st.session_state.get("preferred_models") or final_extraction.get(
+        "preferred_models", []
+    )
+    enable_estimated = st.session_state.get("enable_estimated", True)
 
-    with st.spinner(f"Scoring {len(models_df)} models with MCDM..."):
-        recommendation = fetch_ranked_recommendations(
-            use_case=use_case,
-            user_count=user_count,
-            prompt_tokens=prompt_tokens,
-            output_tokens=output_tokens,
-            expected_qps=float(qps_target),
-            ttft_target_ms=int(ttft_target),
-            itl_target_ms=int(itl_target),
-            e2e_target_ms=int(e2e_target),
-            weights=weights,
-            include_near_miss=False,
-            percentile=percentile,
-            preferred_gpu_types=preferred_gpu_types,
-        )
+    # Build a fingerprint of all spec values so we only re-fetch when inputs change
+    spec_fingerprint = (
+        use_case,
+        user_count,
+        prompt_tokens,
+        output_tokens,
+        float(qps_target),
+        int(ttft_target),
+        int(itl_target),
+        int(e2e_target),
+        tuple(sorted(weights.items())),
+        percentile,
+        tuple(sorted(preferred_gpu_types)),
+        tuple(sorted(preferred_models)),
+        enable_estimated,
+    )
 
-    if recommendation is None:
-        st.error("Unable to get recommendations. Please ensure backend is running.")
-    else:
-        st.session_state.recommendation_result = recommendation
+    # Only fetch recommendations if specs changed or no cached result
+    if (
+        st.session_state.recommendation_result is None
+        or st.session_state.get("_last_spec_fingerprint") != spec_fingerprint
+    ):
+        with st.spinner(f"Scoring {len(models_df)} models with MCDM..."):
+            recommendation = fetch_ranked_recommendations(
+                use_case=use_case,
+                user_count=user_count,
+                prompt_tokens=prompt_tokens,
+                output_tokens=output_tokens,
+                expected_qps=float(qps_target),
+                ttft_target_ms=int(ttft_target),
+                itl_target_ms=int(itl_target),
+                e2e_target_ms=int(e2e_target),
+                weights=weights,
+                include_near_miss=False,
+                percentile=percentile,
+                preferred_gpu_types=preferred_gpu_types,
+                preferred_models=preferred_models,
+                enable_estimated=enable_estimated,
+            )
+
+        if recommendation is None:
+            st.error("Unable to get recommendations. Please ensure backend is running.")
+        else:
+            st.session_state.recommendation_result = recommendation
+            st.session_state._last_spec_fingerprint = spec_fingerprint
 
     if st.session_state.recommendation_result:
         render_recommendation_result(

--- a/ui/app.py
+++ b/ui/app.py
@@ -268,6 +268,7 @@ def render_use_case_input_tab(priority: str, models_df: pd.DataFrame):
                 st.session_state.slo_approved = None
                 st.session_state.edited_extraction = None
                 st.session_state.ranked_response = None
+                st.session_state.preferred_models = extraction.get("preferred_models", [])
                 st.session_state.pop("_last_spec_fingerprint", None)
 
                 for key in [

--- a/ui/components/extraction.py
+++ b/ui/components/extraction.py
@@ -4,6 +4,7 @@ Extraction result display, approval workflow, and edit form.
 """
 
 import streamlit as st
+from api_client import fetch_catalog_model_ids, fetch_gpu_types
 
 
 def _format_priorities(extraction: dict) -> str:
@@ -23,8 +24,16 @@ def _format_priorities(extraction: dict) -> str:
     return ", ".join(parts) if parts else "Default"
 
 
+def _format_models(extraction: dict) -> str:
+    """Format preferred models display."""
+    models = extraction.get("preferred_models", []) or st.session_state.get("preferred_models", [])
+    if not models:
+        return "Any"
+    return ", ".join(models)
+
+
 def render_extraction_result(extraction: dict, priority: str):
-    """Render extraction results (read-only, after approval)."""
+    """Render extraction results (read-only, after approval) with modify button."""
     st.subheader("Extracted Business Context")
 
     use_case = extraction.get("use_case", "unknown")
@@ -32,13 +41,21 @@ def render_extraction_result(extraction: dict, priority: str):
     user_count = extraction.get("user_count", 0)
     hardware = extraction.get("hardware") or "Any GPU"
     priorities = _format_priorities(extraction)
+    models = _format_models(extraction)
 
     st.markdown(
         f"**Use Case:** {use_case_display}  \n"
         f"**Expected Users:** {user_count:,}  \n"
         f"**Hardware:** {hardware}  \n"
+        f"**Models:** {models}  \n"
         f"**Priorities:** {priorities}"
     )
+
+    if st.button("Modify Business Context", use_container_width=False, key="modify_after_approve"):
+        st.session_state.extraction_approved = False
+        st.session_state.slo_approved = None
+        st.session_state.recommendation_result = None
+        st.rerun()
 
 
 def render_extraction_with_approval(extraction: dict, models_df):
@@ -50,11 +67,13 @@ def render_extraction_with_approval(extraction: dict, models_df):
     user_count = extraction.get("user_count", 0)
     hardware = extraction.get("hardware") or "Any GPU"
     priorities = _format_priorities(extraction)
+    models = _format_models(extraction)
 
     st.markdown(
         f"**Use Case:** {use_case_display}  \n"
         f"**Expected Users:** {user_count:,}  \n"
         f"**Hardware:** {hardware}  \n"
+        f"**Models:** {models}  \n"
         f"**Priorities:** {priorities}"
     )
 
@@ -162,18 +181,49 @@ def render_extraction_edit_form(extraction: dict, models_df):
             key="edit_priority",
         )
 
-        hardware_options = ["Any GPU", "H100", "A100", "A10G", "L4", "T4"]
-        current_hardware = extraction.get("hardware") or "Any GPU"
-        hw_idx = (
-            hardware_options.index(current_hardware) if current_hardware in hardware_options else 0
+        # GPU multi-select from catalog
+        gpu_catalog = fetch_gpu_types()
+        gpu_options = sorted(gpu_catalog.keys()) if gpu_catalog else []
+        current_gpus = extraction.get("preferred_gpu_types", [])
+        # Ensure current values are valid options
+        valid_current_gpus = [g for g in current_gpus if g in gpu_options]
+
+        new_gpu_types = st.multiselect(
+            "Hardware (GPUs)",
+            gpu_options,
+            default=valid_current_gpus,
+            key="edit_gpu_types",
+            help="Select one or more GPU types, or leave empty for any GPU",
         )
 
-        new_hardware = st.selectbox(
-            "Hardware",
-            hardware_options,
-            index=hw_idx,
-            key="edit_hardware",
+    # Model selection
+    st.markdown("**Model Preferences** (optional)")
+    col_models, col_custom = st.columns(2)
+    with col_models:
+        # Get catalog models for multiselect
+        catalog_model_ids = fetch_catalog_model_ids()
+        current_models = extraction.get("preferred_models", [])
+        catalog_current = [m for m in current_models if m in catalog_model_ids]
+
+        new_catalog_models = st.multiselect(
+            "Catalog Models",
+            catalog_model_ids,
+            default=catalog_current,
+            key="edit_catalog_models",
+            help="Select from approved model catalog",
         )
+    with col_custom:
+        custom_current = [m for m in current_models if m not in catalog_model_ids]
+        new_custom_models_str = st.text_input(
+            "Custom HuggingFace Model IDs",
+            value=", ".join(custom_current),
+            key="edit_custom_models",
+            help="Comma-separated HuggingFace model IDs (e.g., meta-llama/Llama-3.3-70B-Instruct)",
+        )
+
+    # Merge catalog + custom models
+    custom_models_list = [m.strip() for m in new_custom_models_str.split(",") if m.strip()]
+    all_preferred_models = list(dict.fromkeys(new_catalog_models + custom_models_list))
 
     st.markdown("<br>", unsafe_allow_html=True)
 
@@ -184,8 +234,11 @@ def render_extraction_edit_form(extraction: dict, models_df):
                 "use_case": new_use_case,
                 "user_count": new_user_count,
                 "priority": new_priority,
-                "hardware": new_hardware if new_hardware != "Any GPU" else None,
+                "hardware": ", ".join(new_gpu_types) if new_gpu_types else None,
+                "preferred_gpu_types": new_gpu_types,
+                "preferred_models": all_preferred_models,
             }
+            st.session_state.preferred_models = all_preferred_models
             st.session_state.edited_extraction = edited
             # Apply edits back to extraction_result so the approval view shows updated values
             st.session_state.extraction_result.update(edited)

--- a/ui/components/recommendations.py
+++ b/ui/components/recommendations.py
@@ -62,6 +62,37 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
     replicas = gpu_cfg.get("replicas", 1)
     cost = rec.get("cost_per_month_usd", 0)
 
+    # Confidence badge
+    bench_metrics = rec.get("benchmark_metrics", {}) or {}
+    confidence = bench_metrics.get("confidence_level", "benchmarked")
+    badge_styles = {
+        "benchmarked": ("Benchmarked", "#10B981", "Based on real hardware benchmark data."),
+        "estimated": (
+            "Estimated",
+            "#F59E0B",
+            "Based on roofline model estimation. Actual performance may vary.",
+        ),
+    }
+    badge_label, badge_color, badge_tooltip = badge_styles.get(
+        confidence, badge_styles["benchmarked"]
+    )
+    badge_html = (
+        f'<span title="{badge_tooltip}" style="font-size: 0.7rem; font-weight: 600; '
+        f"color: {badge_color}; border: 1px solid {badge_color}; border-radius: 4px; "
+        f'padding: 1px 6px; margin-left: 8px; vertical-align: middle;">'
+        f"{badge_label}</span>"
+    )
+
+    # Source badge (e.g., "blis", "llm-optimizer")
+    source = bench_metrics.get("source")
+    if source:
+        badge_html += (
+            f'<span title="Data source: {source}" style="font-size: 0.7rem; font-weight: 600; '
+            f"color: #6B7280; border: 1px solid #D1D5DB; border-radius: 4px; "
+            f'padding: 1px 6px; margin-left: 4px; vertical-align: middle;">'
+            f"{source}</span>"
+        )
+
     # Performance metrics (P95)
     ttft = rec.get("predicted_ttft_p95_ms") or 0
     itl = rec.get("predicted_itl_p95_ms") or 0
@@ -94,7 +125,7 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
     with col, st.container(border=True):
         st.markdown(
             f'<div style="line-height: 1.7;">'
-            f'<strong style="font-size: 1.05rem;">{title}</strong><br>'
+            f'<strong style="font-size: 1.05rem;">{title}</strong>{badge_html}<br>'
             f'<span style="font-size: 0.9rem;"><strong>Solution:</strong> Model: {model_name} | Hardware: {hw_count}x {hw_type} | Replicas: {replicas}</span><br>'
             f'<span style="font-size: 0.9rem;"><strong>Scores:</strong> {scores_line}</span><br>'
             f'<span style="font-size: 0.9rem;"><strong>Values:</strong> {metrics_line}</span>'
@@ -251,6 +282,9 @@ def render_options_list_inline():
             meets_slo = rec.get("meets_slo", False)
             slo_value = 1 if meets_slo else 0
 
+            bench_m = rec.get("benchmark_metrics", {}) or {}
+            conf_level = bench_m.get("confidence_level", "benchmarked")
+
             table_data.append(
                 {
                     "category": cat_name,
@@ -262,6 +296,7 @@ def render_options_list_inline():
                     "balanced": balanced,
                     "slo": "Yes" if meets_slo else "No",
                     "slo_value": slo_value,
+                    "confidence": conf_level,
                 }
             )
 
@@ -433,6 +468,13 @@ def render_recommendation_result(result: dict, priority: str, extraction: dict):
     st.session_state.winner_recommendation = winner
     st.session_state.winner_priority = priority
     st.session_state.winner_extraction = extraction
+
+    # Display estimation warnings if any
+    estimation_warnings = ranked_response.get("warnings", []) if ranked_response else []
+    if estimation_warnings:
+        with st.expander(f"Estimation warnings ({len(estimation_warnings)})", expanded=False):
+            for warn in estimation_warnings:
+                st.warning(warn)
 
     st.markdown("---")
 

--- a/ui/components/settings.py
+++ b/ui/components/settings.py
@@ -62,6 +62,18 @@ def render_configuration_tab():
 
     st.divider()
 
+    # --- Estimated Performance ---
+    st.subheader("Estimated Performance")
+    st.toggle(
+        "Enable estimated performance for models without benchmarks",
+        value=st.session_state.get("enable_estimated", True),
+        key="enable_estimated",
+        help="When enabled, the roofline model generates synthetic performance estimates "
+        "for model/GPU combinations that lack benchmark data.",
+    )
+
+    st.divider()
+
     # --- Benchmark Database ---
     st.subheader("Benchmark Database")
 

--- a/ui/components/settings.py
+++ b/ui/components/settings.py
@@ -64,10 +64,15 @@ def render_configuration_tab():
 
     # --- Estimated Performance ---
     st.subheader("Estimated Performance")
+
+    def _on_estimated_change():
+        st.session_state.enable_estimated = st.session_state._enable_estimated_toggle
+
     st.toggle(
         "Enable estimated performance for models without benchmarks",
         value=st.session_state.get("enable_estimated", True),
-        key="enable_estimated",
+        key="_enable_estimated_toggle",
+        on_change=_on_estimated_change,
         help="When enabled, the roofline model generates synthetic performance estimates "
         "for model/GPU combinations that lack benchmark data.",
     )

--- a/ui/components/slo.py
+++ b/ui/components/slo.py
@@ -407,12 +407,34 @@ def render_slo_cards(use_case: str, user_count: int):
         _render_priorities()
 
 
+def _render_constraints(extraction: dict):
+    """Render GPU and model constraints if any are set."""
+    gpu_types = extraction.get("preferred_gpu_types", [])
+    models = extraction.get("preferred_models", []) or st.session_state.get("preferred_models", [])
+
+    if not gpu_types and not models:
+        return
+
+    parts = []
+    if gpu_types:
+        parts.append(f"**GPUs:** {', '.join(gpu_types)}")
+    else:
+        parts.append("**GPUs:** Any")
+    if models:
+        parts.append(f"**Models:** {', '.join(models)}")
+    else:
+        parts.append("**Models:** Any")
+
+    st.markdown(" &nbsp;|&nbsp; ".join(parts))
+
+
 def render_slo_with_approval(extraction: dict):
     """Render SLO section with approval to proceed to recommendations."""
     use_case = extraction.get("use_case", "chatbot_conversational")
     user_count = extraction.get("user_count", 1000)
 
     render_slo_cards(use_case, user_count)
+    _render_constraints(extraction)
 
     # Validate SLO values
     slo_defaults = fetch_slo_defaults(use_case)

--- a/ui/components/slo.py
+++ b/ui/components/slo.py
@@ -488,6 +488,8 @@ def render_slo_with_approval(extraction: dict):
             disabled=not is_valid,
         ):
             st.session_state.slo_approved = True
+            st.session_state.recommendation_result = None
+            st.session_state.pop("_last_spec_fingerprint", None)
             st.session_state._pending_tab = 2
             for _cat in ("balanced", "accuracy", "latency", "cost"):
                 st.session_state[f"cat_idx_{_cat}"] = 0

--- a/ui/state.py
+++ b/ui/state.py
@@ -50,6 +50,9 @@ SESSION_DEFAULTS: dict[str, Any] = {
     "cat_idx_accuracy": 0,
     "cat_idx_latency": 0,
     "cat_idx_cost": 0,
+    # Estimated performance
+    "preferred_models": [],
+    "enable_estimated": True,
     # Deployment tab
     "deployment_selected_config": None,
     "deployment_yaml_files": {},


### PR DESCRIPTION
  ## Summary

  - Add estimated performance flow using BentoML roofline model (llm-optimizer) as a fallback when no benchmark data exists for a model/GPU combination
  - Support user-specified preferred models in intent extraction, UI, and recommendation pipeline — preferred models bypass the min_accuracy filter so they always appear in results
  - Persist roofline estimates to the DB (`source='llm-optimizer'`, `confidence_level='estimated'`) for cache hits on subsequent requests
  - Add `confidence_level` column to `exported_summaries` schema with 3-tier trust classification: `benchmarked`, `simulated`, `estimated`
  - Display confidence badges in the UI with toggle to enable/disable estimated results
  - Cache recommendation results using spec fingerprinting to avoid redundant API calls on Streamlit widget interactions
  - Add design document at `docs/design/estimated-performance.md`

  ## Test plan

  - [ x] 443-line unit test suite covering estimation pipeline, deduplication, SLO filtering, DB persistence, and edge cases
  - [ x] Integration test hitting real HuggingFace API and llm-optimizer with Qwen/Qwen2.5-0.5B (ungated model)
  - [ x] Run `make test-unit` — all 126 tests pass
  - [ x] Run `make lint && make typecheck` — clean
  - [ x] Manual E2E test: query with mix of catalog models (with benchmarks) and non-catalog models (estimated) — all preferred models appear in results

Fixes #137