### PR TITLE
chore: add Dependabot configuration for weekly version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+updates:
+  # Python dependencies (main project via uv/pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # Python dependencies (UI Dockerfile)
+  - package-ecosystem: "pip"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # Python dependencies (simulator Dockerfile)
+  - package-ecosystem: "pip"
+    directory: "/simulator"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/simulator"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Configure Dependabot for pip (root, ui, simulator), Docker base images, and GitHub Actions with a weekly schedule. Minor/patch pip updates are grouped to reduce PR noise.

I enabled Dependabot security updates on the repo yesterday, but that just monitors for security issues.  With this configuration, Dependabot will keep us up to date on all dependencies.  We used it on my last project.  It may be a little extra work the first time around, as all of our dependencies are updated to the latest stable versions, but it helps in the long run to stay up to date with bug fixes incrementally.