### PR TITLE
fix: remove stale mypy and ruff suppressions from UI files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,9 +123,6 @@ line-ending = "auto"
 "tests/**/*.py" = ["E501", "F401"]
 "test_*.py" = ["E501", "F401"]
 
-# UI files use star imports from internal capacity_planner module
-"ui/**/*.py" = ["F403", "F405"]
-
 [tool.ruff.lint.isort]
 # Organize imports into sections
 known-first-party = ["planner"]

--- a/ui/pages/1_Capacity_Planner.py
+++ b/ui/pages/1_Capacity_Planner.py
@@ -1,7 +1,6 @@
 """
 Main Page
 """
-# mypy: disable-error-code="call-overload,assignment,index,misc,arg-type"
 
 import json
 from pathlib import Path

--- a/ui/pages/2_GPU_Recommender.py
+++ b/ui/pages/2_GPU_Recommender.py
@@ -2,7 +2,6 @@
 GPU Recommender Page - Streamlit UI for GPU recommendation engine
 This page helps users find the optimal GPU for running LLM inference.
 """
-# mypy: disable-error-code="assignment"
 
 import json
 


### PR DESCRIPTION
The star imports that required these suppressions have been replaced with explicit imports. Remove the now-unnecessary blanket mypy disable-error-code directives and the ruff F403/F405 per-file-ignores.

Fixes #153