### PR TITLE
fix: normalize hallucinated use_case values in intent extraction

### DIFF
--- a/src/planner/intent_extraction/extractor.py
+++ b/src/planner/intent_extraction/extractor.py
@@ -1,8 +1,10 @@
 """Intent extraction from conversational input."""
 
+import difflib
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import get_args
 
 from planner.llm.ollama_client import OllamaClient
 from planner.llm.prompts import INTENT_EXTRACTION_SCHEMA, build_intent_extraction_prompt
@@ -13,6 +15,23 @@ logger = logging.getLogger(__name__)
 # Create prompts directory for easy copy-paste access
 PROMPTS_DIR = Path(__file__).parent.parent.parent.parent / "logs" / "prompts"
 PROMPTS_DIR.mkdir(parents=True, exist_ok=True)
+
+# Common LLM hallucinations mapped to valid use_case values
+_USE_CASE_ALIASES: dict[str, str] = {
+    "summarization": "summarization_short",
+    "text_summarization": "summarization_short",
+    "document_summarization": "long_document_summarization",
+    "chatbot": "chatbot_conversational",
+    "chat": "chatbot_conversational",
+    "code_gen": "code_generation_detailed",
+    "code_generation": "code_generation_detailed",
+    "rag": "document_analysis_rag",
+    "document_qa": "document_analysis_rag",
+    "legal_analysis": "research_legal_analysis",
+    "research_analysis": "research_legal_analysis",
+    "research": "research_legal_analysis",
+    "content": "content_generation",
+}
 
 
 class IntentExtractor:
@@ -140,6 +159,20 @@ class IntentExtractor:
             # LLM sometimes returns "chatbot|customer_service|..." instead of just "chatbot"
             # Take the first option
             cleaned["use_case"] = cleaned["use_case"].split("|")[0].strip()
+
+        # Normalize hallucinated use_case values
+        use_case = cleaned.get("use_case", "")
+        valid_use_cases = list(get_args(DeploymentIntent.model_fields["use_case"].annotation))
+        if use_case not in valid_use_cases:
+            mapped = _USE_CASE_ALIASES.get(use_case)
+            if mapped:
+                logger.info("Mapped hallucinated use_case '%s' -> '%s'", use_case, mapped)
+                cleaned["use_case"] = mapped
+            else:
+                close = difflib.get_close_matches(use_case, valid_use_cases, n=1, cutoff=0.6)
+                if close:
+                    logger.info("Fuzzy-matched use_case '%s' -> '%s'", use_case, close[0])
+                    cleaned["use_case"] = close[0]
 
         # Infer experience_class if not provided
         if "experience_class" not in cleaned or not cleaned.get("experience_class"):

--- a/src/planner/llm/prompts.py
+++ b/src/planner/llm/prompts.py
@@ -27,6 +27,8 @@ Use case descriptions:
 - long_document_summarization: Long document summarization (very long prompts, medium summaries)
 - research_legal_analysis: Research/legal document analysis (very long prompts, detailed analysis)
 
+CRITICAL: The use_case value MUST be exactly one of the 9 values listed above. Do not invent variations like "text_summarization" or "chatbot" — use the exact strings shown.
+
 Experience class guidance:
 - instant: Sub-200ms response time - code completion, autocomplete
 - conversational: Real-time user interaction - chatbots, interactive tools

--- a/tests/unit/test_intent_extractor.py
+++ b/tests/unit/test_intent_extractor.py
@@ -1,0 +1,132 @@
+"""Unit tests for IntentExtractor._clean_llm_output() use_case normalization."""
+
+import pytest
+
+from planner.intent_extraction.extractor import IntentExtractor
+from planner.shared.schemas import DeploymentIntent
+
+
+@pytest.fixture
+def extractor():
+    """IntentExtractor with no LLM client (only testing _clean_llm_output)."""
+    return IntentExtractor(llm_client=None)
+
+
+def _base_intent(**overrides) -> dict:
+    """Build a minimal valid raw LLM output dict with overrides."""
+    data = {
+        "use_case": "chatbot_conversational",
+        "experience_class": "conversational",
+        "user_count": 500,
+        "accuracy_priority": "medium",
+        "cost_priority": "medium",
+        "latency_priority": "medium",
+        "complexity_priority": "medium",
+    }
+    data.update(overrides)
+    return data
+
+
+# --- Alias mapping tests ---
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "hallucinated, expected",
+    [
+        ("text_summarization", "summarization_short"),
+        ("summarization", "summarization_short"),
+        ("document_summarization", "long_document_summarization"),
+        ("chatbot", "chatbot_conversational"),
+        ("chat", "chatbot_conversational"),
+        ("code_gen", "code_generation_detailed"),
+        ("code_generation", "code_generation_detailed"),
+        ("rag", "document_analysis_rag"),
+        ("document_qa", "document_analysis_rag"),
+        ("legal_analysis", "research_legal_analysis"),
+        ("research_analysis", "research_legal_analysis"),
+        ("research", "research_legal_analysis"),
+        ("content", "content_generation"),
+    ],
+)
+def test_clean_llm_output_maps_alias_to_valid_use_case(extractor, hallucinated, expected):
+    """Known hallucinated use_case values are mapped to valid ones."""
+    raw = _base_intent(use_case=hallucinated)
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned["use_case"] == expected
+
+
+# --- Valid values pass through unchanged ---
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "valid_use_case",
+    [
+        "chatbot_conversational",
+        "code_completion",
+        "code_generation_detailed",
+        "translation",
+        "content_generation",
+        "summarization_short",
+        "document_analysis_rag",
+        "long_document_summarization",
+        "research_legal_analysis",
+    ],
+)
+def test_clean_llm_output_preserves_valid_use_case(extractor, valid_use_case):
+    """Already-valid use_case values pass through unchanged."""
+    raw = _base_intent(use_case=valid_use_case)
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned["use_case"] == valid_use_case
+
+
+# --- Fuzzy matching tests ---
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "typo, expected",
+    [
+        ("summarization_shorts", "summarization_short"),
+        ("chatbot_conversatonal", "chatbot_conversational"),
+        ("code_compltion", "code_completion"),
+    ],
+)
+def test_clean_llm_output_fuzzy_matches_close_typos(extractor, typo, expected):
+    """Typos close to valid values are fuzzy-matched."""
+    raw = _base_intent(use_case=typo)
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned["use_case"] == expected
+
+
+# --- Garbage values are NOT matched ---
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("garbage", ["banana", "xyz_123", "do_something"])
+def test_clean_llm_output_does_not_match_garbage(extractor, garbage):
+    """Completely unrelated values are left unchanged (Pydantic will reject them)."""
+    raw = _base_intent(use_case=garbage)
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned["use_case"] == garbage
+
+
+# --- Integration: full parse with mocked hallucinated value ---
+
+
+@pytest.mark.unit
+def test_parse_extracted_intent_succeeds_with_hallucinated_use_case(extractor):
+    """A hallucinated use_case is normalized and parses into a valid DeploymentIntent."""
+    raw = _base_intent(use_case="text_summarization")
+    intent = extractor._parse_extracted_intent(raw)
+    assert isinstance(intent, DeploymentIntent)
+    assert intent.use_case == "summarization_short"
+
+
+@pytest.mark.unit
+def test_parse_extracted_intent_fails_with_garbage_use_case(extractor):
+    """A garbage use_case that can't be normalized still raises ValueError."""
+    raw = _base_intent(use_case="banana")
+    with pytest.raises(ValueError, match="Invalid intent data"):
+        extractor._parse_extracted_intent(raw)


### PR DESCRIPTION
## Description

**Background:**

This issue was detected when doing integration work with the Red Hat OpenShift AI MCP server [tool for llm-d-planner](https://github.com/opendatahub-io/rhoai-mcp/tree/main/src/rhoai_mcp/composites/neuralnav).
I was repeatedly getting HTTP 422 when interacting with the llm-d-planner backend when trying to get model recommendations for very simple requests (_e.g._, "_I need a model recommendation for text summarization_").

**The problem**:

The LLM we use for intent extraction sometimes returns plausible-but-invalid `use_case` values during intent extraction - for example `"text_summarization"` instead of the valid `"summarization_short"`. The Pydantic `Literal` validation rejects these with HTTP 422, causing the entire recommendation flow to fail.

This PR adds a normalization layer in `_clean_llm_output()` with two mechanisms:

1. **Alias map** - 13 known hallucination patterns mapped to valid values (_e.g._, `"chatbot"` -> `"chatbot_conversational"`, `"rag"` -> `"document_analysis_rag"`)
2. **Fuzzy matching** - `difflib.get_close_matches()` with cutoff 0.6 as fallback for typos (_e.g._, `"summarization_shorts"` -> `"summarization_short"`)

Additionally, the extraction prompt is reinforced with an explicit constraint reminding the model to use only the 9 valid use_case values.

**Files changed:**
- `src/planner/intent_extraction/extractor.py` - alias map + fuzzy normalization
- `src/planner/llm/prompts.py` - prompt reinforcement line
- `tests/unit/test_intent_extractor.py` - 30 new unit tests

## How Has This Been Tested?

- 30 unit tests covering alias mapping (13 cases), valid passthrough (9 cases), fuzzy matching (3 cases), garbage rejection (3 cases), and integration parse tests (2 cases)
- All 189 unit tests pass
- Ruff linter clean on all changed files
- Deployment has been verified against a ROSA cluster

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving
changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes
work