### PR TITLE
Add intent extraction test suite and fix priority extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -530,7 +530,7 @@ test: test-unit test-db test-integration ## Run all tests (requires DB and Ollam
 
 test-unit: ## Run unit tests (no DB or Ollama required)
 	@printf "$(BLUE)Running unit tests...$(NC)\n"
-	cd $(SRC_DIR) && uv run pytest ../tests/ -v -m "not database and not integration"
+	cd $(SRC_DIR) && uv run pytest ../tests/ -v -m "not database and not integration and not intent_extraction"
 
 test-db: ## Run database tests (requires PostgreSQL with benchmark data)
 	@printf "$(BLUE)Running database tests...$(NC)\n"
@@ -539,6 +539,10 @@ test-db: ## Run database tests (requires PostgreSQL with benchmark data)
 test-integration: setup-ollama ## Run integration tests (requires Ollama and DB)
 	@printf "$(BLUE)Running integration tests...$(NC)\n"
 	cd $(SRC_DIR) && uv run pytest ../tests/ -v -m integration
+
+test-intent: setup-ollama ## Run intent extraction tests (requires Ollama)
+	@printf "$(BLUE)Running intent extraction tests...$(NC)\n"
+	cd $(SRC_DIR) && uv run pytest ../tests/ -v -m intent_extraction
 
 ##@ Code Quality
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ asyncio_default_fixture_loop_scope = "session"
 markers = [
     "database: marks tests that require a running PostgreSQL database with benchmark data",
     "integration: marks tests as integration tests (requires Ollama and database)",
+    "intent_extraction: marks tests that validate LLM intent extraction (requires Ollama, run with make test-intent)",
     "unit: marks tests as unit tests (no external dependencies)",
 ]
 

--- a/src/planner/intent_extraction/extractor.py
+++ b/src/planner/intent_extraction/extractor.py
@@ -2,12 +2,13 @@
 
 import difflib
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import get_args
 
 from planner.llm.ollama_client import OllamaClient
-from planner.llm.prompts import INTENT_EXTRACTION_SCHEMA, build_intent_extraction_prompt
+from planner.llm.prompts import build_intent_extraction_prompt
 from planner.shared.schemas import ConversationMessage, DeploymentIntent
 
 logger = logging.getLogger(__name__)
@@ -76,15 +77,13 @@ class IntentExtractor:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         prompt_file = PROMPTS_DIR / f"intent_extraction_{timestamp}.txt"
 
-        full_prompt_with_schema = f"{prompt}\n\n{INTENT_EXTRACTION_SCHEMA}"
-
         with open(prompt_file, "w") as f:
             f.write("=" * 80 + "\n")
             f.write("INTENT EXTRACTION PROMPT\n")
             f.write(f"Generated: {datetime.now().isoformat()}\n")
             f.write(f"User Message: {user_message}\n")
             f.write("=" * 80 + "\n\n")
-            f.write(full_prompt_with_schema)
+            f.write(prompt)
             f.write("\n\n" + "=" * 80 + "\n")
             f.write("Copy everything above this line to test in other LLMs\n")
             f.write("=" * 80 + "\n")
@@ -93,8 +92,6 @@ class IntentExtractor:
         logger.info("=" * 80)
         logger.info("[FULL INTENT EXTRACTION PROMPT - START]")
         logger.info(prompt)
-        logger.info("[SCHEMA BEING USED]")
-        logger.info(INTENT_EXTRACTION_SCHEMA)
         logger.info("[FULL INTENT EXTRACTION PROMPT - END]")
         logger.info(f"💾 Prompt saved to: {prompt_file}")
         logger.info("=" * 80)
@@ -103,7 +100,6 @@ class IntentExtractor:
             # Extract structured data from LLM
             extracted = self.llm_client.extract_structured_data(
                 prompt,
-                INTENT_EXTRACTION_SCHEMA,
                 temperature=0.3,  # Lower temperature for more consistent extraction
             )
 
@@ -111,7 +107,7 @@ class IntentExtractor:
             logger.info(f"[EXTRACTED INTENT] {extracted}")
 
             # Validate and parse into Pydantic model
-            intent = self._parse_extracted_intent(extracted)
+            intent = self._parse_extracted_intent(extracted, user_message)
             logger.info(f"Extracted intent: use_case={intent.use_case}, users={intent.user_count}")
 
             return intent
@@ -120,12 +116,13 @@ class IntentExtractor:
             logger.error(f"Failed to extract intent: {e}")
             raise ValueError(f"Intent extraction failed: {e}") from e
 
-    def _parse_extracted_intent(self, raw_data: dict) -> DeploymentIntent:
+    def _parse_extracted_intent(self, raw_data: dict, user_message: str = "") -> DeploymentIntent:
         """
         Parse and validate raw LLM output into DeploymentIntent.
 
         Args:
             raw_data: Raw dict from LLM
+            user_message: Original user message for priority validation
 
         Returns:
             Validated DeploymentIntent
@@ -134,7 +131,7 @@ class IntentExtractor:
             ValueError: If data is invalid
         """
         # Handle common LLM mistakes
-        cleaned_data = self._clean_llm_output(raw_data)
+        cleaned_data = self._clean_llm_output(raw_data, user_message)
 
         try:
             return DeploymentIntent(**cleaned_data)
@@ -142,12 +139,13 @@ class IntentExtractor:
             logger.error(f"Failed to parse intent from: {cleaned_data}")
             raise ValueError(f"Invalid intent data: {e}") from e
 
-    def _clean_llm_output(self, data: dict) -> dict:
+    def _clean_llm_output(self, data: dict, user_message: str = "") -> dict:
         """
         Clean common LLM output mistakes.
 
         Args:
             data: Raw LLM output
+            user_message: Original user message for priority validation
 
         Returns:
             Cleaned data dict
@@ -161,7 +159,8 @@ class IntentExtractor:
             cleaned["use_case"] = cleaned["use_case"].split("|")[0].strip()
 
         # Normalize hallucinated use_case values
-        use_case = cleaned.get("use_case", "")
+        use_case = cleaned.get("use_case", "").lower()
+        cleaned["use_case"] = use_case
         valid_use_cases = list(get_args(DeploymentIntent.model_fields["use_case"].annotation))
         if use_case not in valid_use_cases:
             mapped = _USE_CASE_ALIASES.get(use_case)
@@ -173,6 +172,14 @@ class IntentExtractor:
                 if close:
                     logger.info("Fuzzy-matched use_case '%s' -> '%s'", use_case, close[0])
                     cleaned["use_case"] = close[0]
+                else:
+                    logger.warning(
+                        "Unrecognized use_case '%s' — no alias or fuzzy match found", use_case
+                    )
+
+        # Normalize experience_class to lowercase if provided by LLM
+        if "experience_class" in cleaned and isinstance(cleaned["experience_class"], str):
+            cleaned["experience_class"] = cleaned["experience_class"].lower()
 
         # Infer experience_class if not provided
         if "experience_class" not in cleaned or not cleaned.get("experience_class"):
@@ -203,8 +210,6 @@ class IntentExtractor:
         # Fix user_count if it's a descriptive string instead of integer
         if "user_count" in cleaned and isinstance(cleaned["user_count"], str):
             # Extract integer from strings like "thousands of users (estimated: 5,000 - 10,000)"
-            import re
-
             user_count_str = cleaned["user_count"]
 
             # Try to find numbers with commas or ranges
@@ -249,31 +254,46 @@ class IntentExtractor:
                         f"Could not parse user_count from '{user_count_str}', defaulting to 1000"
                     )
 
-        # Ensure domain_specialization is a list
+        # Ensure domain_specialization is a list with lowercase values
         if "domain_specialization" in cleaned:
             if isinstance(cleaned["domain_specialization"], str):
-                # Convert single string to list
-                cleaned["domain_specialization"] = [cleaned["domain_specialization"]]
-            elif "|" in str(cleaned.get("domain_specialization", "")):
-                # Handle "general|code" format
+                if "|" in cleaned["domain_specialization"]:
+                    # Handle "general|code" format
+                    cleaned["domain_specialization"] = [
+                        d.strip().lower() for d in cleaned["domain_specialization"].split("|")
+                    ]
+                else:
+                    # Convert single string to list
+                    cleaned["domain_specialization"] = [cleaned["domain_specialization"].lower()]
+            elif isinstance(cleaned["domain_specialization"], list):
                 cleaned["domain_specialization"] = [
-                    d.strip() for d in cleaned["domain_specialization"].split("|")
+                    d.lower() if isinstance(d, str) else d for d in cleaned["domain_specialization"]
                 ]
 
         # Ensure priority fields have valid values (default to "medium" if invalid/missing)
         valid_priorities = ["low", "medium", "high"]
+        # Map common LLM variations to valid values before discarding
+        _priority_aliases = {
+            "very_high": "high",
+            "very high": "high",
+            "critical": "high",
+            "very_low": "low",
+            "very low": "low",
+            "none": "low",
+        }
         for priority_field in [
             "accuracy_priority",
             "cost_priority",
             "latency_priority",
-            "complexity_priority",
         ]:
             if priority_field in cleaned:
                 # Normalize to lowercase and validate
                 priority_value = str(cleaned[priority_field]).lower().strip()
+                priority_value = _priority_aliases.get(priority_value, priority_value)
                 if priority_value not in valid_priorities:
                     logger.info(
-                        f"Invalid {priority_field}='{cleaned[priority_field]}', defaulting to 'medium'"
+                        f"Invalid {priority_field}='{cleaned[priority_field]}', "
+                        f"defaulting to 'medium'"
                     )
                     cleaned[priority_field] = "medium"
                 else:
@@ -282,6 +302,27 @@ class IntentExtractor:
                 # Field not provided by LLM, default to medium
                 cleaned[priority_field] = "medium"
 
+        # Enforce explicit-only priority extraction.
+        # The LLM returns *_mentioned booleans alongside *_priority values.
+        # Trust the LLM's priority only when it reports the user mentioned the
+        # topic.  Otherwise reset to medium — the LLM is likely inferring from
+        # use-case type rather than from what the user said.  The SLO profiles
+        # already handle use-case-appropriate targets.
+        for prefix in ("accuracy", "cost", "latency"):
+            mentioned_key = f"{prefix}_mentioned"
+            priority_key = f"{prefix}_priority"
+            mentioned_raw = cleaned.pop(mentioned_key, False)
+            mentioned = (
+                str(mentioned_raw).lower() == "true"
+                if isinstance(mentioned_raw, str)
+                else bool(mentioned_raw)
+            )
+            if not mentioned and cleaned.get(priority_key, "medium") != "medium":
+                logger.info(
+                    f"Resetting {priority_key} from '{cleaned[priority_key]}' to 'medium' "
+                    f"(LLM reported {mentioned_key}=false)"
+                )
+                cleaned[priority_key] = "medium"
         # Remove any unexpected fields that aren't in the schema
         valid_fields = DeploymentIntent.model_fields.keys()
         cleaned = {k: v for k, v in cleaned.items() if k in valid_fields}
@@ -302,11 +343,7 @@ class IntentExtractor:
         if intent.domain_specialization == ["general"]:
             if intent.use_case in ["code_generation_detailed", "code_completion"]:
                 intent.domain_specialization = ["general", "code"]
-            elif intent.use_case == "translation" or (
-                "multilingual" in intent.additional_context.lower()
-                if intent.additional_context
-                else False
-            ):
+            elif intent.use_case == "translation":
                 intent.domain_specialization = ["general", "multilingual"]
 
         return intent

--- a/src/planner/intent_extraction/extractor.py
+++ b/src/planner/intent_extraction/extractor.py
@@ -261,6 +261,12 @@ class IntentExtractor:
                         f"Could not parse user_count from '{user_count_str}', defaulting to 1000"
                     )
 
+        # Guard against user_count=0 (the schema default the LLM echoes when
+        # it fails to extract): 0 users is never meaningful.
+        if cleaned.get("user_count", 1) <= 0:
+            cleaned["user_count"] = 100
+            logger.warning("user_count was <= 0, defaulting to 100")
+
         # Ensure domain_specialization is a list with lowercase values
         if "domain_specialization" in cleaned:
             if isinstance(cleaned["domain_specialization"], str):

--- a/src/planner/intent_extraction/extractor.py
+++ b/src/planner/intent_extraction/extractor.py
@@ -18,6 +18,15 @@ PROMPTS_DIR = Path(__file__).parent.parent.parent.parent / "logs" / "prompts"
 PROMPTS_DIR.mkdir(parents=True, exist_ok=True)
 
 # Common LLM hallucinations mapped to valid use_case values
+_PRIORITY_ALIASES: dict[str, str] = {
+    "very_high": "high",
+    "very high": "high",
+    "critical": "high",
+    "very_low": "low",
+    "very low": "low",
+    "none": "low",
+}
+
 _USE_CASE_ALIASES: dict[str, str] = {
     "summarization": "summarization_short",
     "text_summarization": "summarization_short",
@@ -107,7 +116,7 @@ class IntentExtractor:
             logger.info(f"[EXTRACTED INTENT] {extracted}")
 
             # Validate and parse into Pydantic model
-            intent = self._parse_extracted_intent(extracted, user_message)
+            intent = self._parse_extracted_intent(extracted)
             logger.info(f"Extracted intent: use_case={intent.use_case}, users={intent.user_count}")
 
             return intent
@@ -116,13 +125,12 @@ class IntentExtractor:
             logger.error(f"Failed to extract intent: {e}")
             raise ValueError(f"Intent extraction failed: {e}") from e
 
-    def _parse_extracted_intent(self, raw_data: dict, user_message: str = "") -> DeploymentIntent:
+    def _parse_extracted_intent(self, raw_data: dict) -> DeploymentIntent:
         """
         Parse and validate raw LLM output into DeploymentIntent.
 
         Args:
             raw_data: Raw dict from LLM
-            user_message: Original user message for priority validation
 
         Returns:
             Validated DeploymentIntent
@@ -131,7 +139,7 @@ class IntentExtractor:
             ValueError: If data is invalid
         """
         # Handle common LLM mistakes
-        cleaned_data = self._clean_llm_output(raw_data, user_message)
+        cleaned_data = self._clean_llm_output(raw_data)
 
         try:
             return DeploymentIntent(**cleaned_data)
@@ -139,13 +147,12 @@ class IntentExtractor:
             logger.error(f"Failed to parse intent from: {cleaned_data}")
             raise ValueError(f"Invalid intent data: {e}") from e
 
-    def _clean_llm_output(self, data: dict, user_message: str = "") -> dict:
+    def _clean_llm_output(self, data: dict) -> dict:
         """
         Clean common LLM output mistakes.
 
         Args:
             data: Raw LLM output
-            user_message: Original user message for priority validation
 
         Returns:
             Cleaned data dict
@@ -272,15 +279,6 @@ class IntentExtractor:
 
         # Ensure priority fields have valid values (default to "medium" if invalid/missing)
         valid_priorities = ["low", "medium", "high"]
-        # Map common LLM variations to valid values before discarding
-        _priority_aliases = {
-            "very_high": "high",
-            "very high": "high",
-            "critical": "high",
-            "very_low": "low",
-            "very low": "low",
-            "none": "low",
-        }
         for priority_field in [
             "accuracy_priority",
             "cost_priority",
@@ -289,7 +287,7 @@ class IntentExtractor:
             if priority_field in cleaned:
                 # Normalize to lowercase and validate
                 priority_value = str(cleaned[priority_field]).lower().strip()
-                priority_value = _priority_aliases.get(priority_value, priority_value)
+                priority_value = _PRIORITY_ALIASES.get(priority_value, priority_value)
                 if priority_value not in valid_priorities:
                     logger.info(
                         f"Invalid {priority_field}='{cleaned[priority_field]}', "
@@ -308,10 +306,12 @@ class IntentExtractor:
         # topic.  Otherwise reset to medium — the LLM is likely inferring from
         # use-case type rather than from what the user said.  The SLO profiles
         # already handle use-case-appropriate targets.
+        # Default to True (trust the priority) when the LLM omits *_mentioned
+        # entirely, so a missing field doesn't silently discard valid priorities.
         for prefix in ("accuracy", "cost", "latency"):
             mentioned_key = f"{prefix}_mentioned"
             priority_key = f"{prefix}_priority"
-            mentioned_raw = cleaned.pop(mentioned_key, False)
+            mentioned_raw = cleaned.pop(mentioned_key, True)
             mentioned = (
                 str(mentioned_raw).lower() == "true"
                 if isinstance(mentioned_raw, str)

--- a/src/planner/llm/ollama_client.py
+++ b/src/planner/llm/ollama_client.py
@@ -127,29 +127,19 @@ class OllamaClient:
     def extract_structured_data(
         self,
         prompt: str,
-        schema_description: str,
         temperature: float = 0.3,
     ) -> dict[str, Any]:
         """
         Extract structured data from prompt using JSON format.
 
         Args:
-            prompt: Input prompt describing what to extract
-            schema_description: Description of expected JSON schema
+            prompt: Input prompt (should include schema and instructions)
             temperature: Lower temperature for more consistent extraction
 
         Returns:
             Parsed JSON dict
         """
-        full_prompt = f"""{prompt}
-
-{schema_description}
-
-Return ONLY valid JSON matching the schema above. Do not include any explanation or additional text."""
-
-        response_text = self.generate_completion(
-            full_prompt, format_json=True, temperature=temperature
-        )
+        response_text = self.generate_completion(prompt, format_json=True, temperature=temperature)
 
         try:
             result: dict[str, Any] = json.loads(response_text)

--- a/src/planner/llm/prompts.py
+++ b/src/planner/llm/prompts.py
@@ -1,42 +1,5 @@
 """Prompt templates for LLM interactions."""
 
-INTENT_EXTRACTION_SCHEMA = """
-Expected JSON schema:
-{
-  "use_case": "chatbot_conversational|code_completion|code_generation_detailed|translation|content_generation|summarization_short|document_analysis_rag|long_document_summarization|research_legal_analysis",
-  "experience_class": "instant|conversational|interactive|deferred|batch",
-  "user_count": <integer>,
-  "domain_specialization": ["general"|"code"|"multilingual"|"enterprise"],
-  "preferred_gpu_types": ["<list of GPU types if mentioned, empty list if not specified>"],
-  "preferred_models": ["<list of model IDs in HuggingFace format if mentioned, empty list if not specified>"],
-  "accuracy_priority": "low|medium|high",
-  "cost_priority": "low|medium|high",
-  "latency_priority": "low|medium|high",
-  "complexity_priority": "low|medium|high",
-  "additional_context": "<any other relevant details mentioned>"
-}
-
-Use case descriptions:
-- chatbot_conversational: Real-time conversational chatbots (short prompts, short responses)
-- code_completion: Fast code completion/autocomplete (short prompts, short completions)
-- code_generation_detailed: Detailed code generation with explanations (medium prompts, long responses)
-- translation: Document translation (medium prompts, medium responses)
-- content_generation: Content creation, marketing copy (medium prompts, medium responses)
-- summarization_short: Short document summarization (medium prompts, short summaries)
-- document_analysis_rag: RAG-based document Q&A (long prompts with context, medium responses)
-- long_document_summarization: Long document summarization (very long prompts, medium summaries)
-- research_legal_analysis: Research/legal document analysis (very long prompts, detailed analysis)
-
-CRITICAL: The use_case value MUST be exactly one of the 9 values listed above. Do not invent variations like "text_summarization" or "chatbot" — use the exact strings shown.
-
-Experience class guidance:
-- instant: Sub-200ms response time - code completion, autocomplete
-- conversational: Real-time user interaction - chatbots, interactive tools
-- interactive: User waiting but tolerates slight delay - RAG Q&A, content generation
-- deferred: Quality over speed - long summarization, detailed analysis
-- batch: Background/async processing - research, legal analysis
-"""
-
 
 def build_intent_extraction_prompt(
     user_message: str, conversation_history: list | None = None
@@ -60,60 +23,83 @@ def build_intent_extraction_prompt(
             context += f"{role}: {content}\n"
         context += "\n"
 
-    prompt = f"""You are an expert AI assistant for Planner helping users deploy Large Language Models (LLMs) for production use cases.
+    prompt = f"""Extract deployment requirements from the user message.
 
-{context}Current user message: {user_message}
+Return JSON only. No explanation.
 
-Your task is to extract structured information about their deployment requirements. Analyze what they've said and infer:
+{context}User message: {user_message}
 
-1. **Use case**: What type of application (chatbot, customer service, code generation, summarization, etc.)
-2. **User count**: How many users or scale mentioned (estimate if not explicit)
-3. **Domain specialization**: Any specific domains mentioned (code, multilingual, enterprise, etc.)
-4. **Latency requirement**: How important is low latency? (very_high = sub-500ms, high = sub-2s, medium = 2-5s, low = >5s acceptable)
-5. **Throughput priority**: Is high request volume more important than low latency?
-6. **Budget constraint**: How price-sensitive are they?
-7. **Domain specialization**: Any specific domains mentioned (code, multilingual, enterprise, etc.)
-8. **Preferred GPU(s)**: If user mentions specific GPU types (H100, H200, A100, A100-80, A100-40, L4, B200), extract them as a list
+Schema:
+{{
+  "use_case": "chatbot_conversational|code_completion|code_generation_detailed|translation|content_generation|summarization_short|document_analysis_rag|long_document_summarization|research_legal_analysis",
+  "user_count": 0,
+  "domain_specialization": [],
+  "preferred_gpu_types": [],
+  "preferred_models": [],
+  "accuracy_mentioned": false,
+  "accuracy_priority": "medium",
+  "cost_mentioned": false,
+  "cost_priority": "medium",
+  "latency_mentioned": false,
+  "latency_priority": "medium"
+}}
 
-Be intelligent about inference:
-- "thousands of users" → estimate specific number
-- "document Q&A" or "knowledge base" or "document search" → use_case: document_analysis_rag
-- "RAG" or "retrieval" → use_case: document_analysis_rag
-- "chatbot" or "customer service" or "conversational" → use_case: chatbot_conversational
-- "content" or "marketing" or "blog" or "content generation" → use_case: content_generation
-- "summarize document" or "summarization" → use_case: summarization_short or long_document_summarization
+Rules:
 
-GPU extraction examples (canonical names: L4, A100-40, A100-80, H100, H200, B200):
-- "running on h200" or "h200" or "H200" → preferred_gpu_types: ["H200"]
-- "h100 or h200" → preferred_gpu_types: ["H100", "H200"]
-- "a100" or "A100" (unspecified variant) → preferred_gpu_types: ["A100-80", "A100-40"]
-- "a100-80" or "A100-80GB" → preferred_gpu_types: ["A100-80"]
-- "l4" or "L4" → preferred_gpu_types: ["L4"]
-- No GPU mentioned → preferred_gpu_types: []
+GENERAL:
 
-Model extraction examples (use HuggingFace format from model catalog):
-- "deploy Llama 3.3 70B" or "use llama 70b" → preferred_models: ["meta-llama/Llama-3.3-70B-Instruct"]
-- "I want to use Qwen3-32B" → preferred_models: ["Qwen/Qwen3-32B"]
-- "compare granite and llama for my use case" → preferred_models: ["ibm-granite/granite-3.1-8b-instruct", "meta-llama/Llama-3.1-8B-Instruct"]
-- "run mistral small" → preferred_models: ["mistralai/Mistral-Small-24B-Instruct-2501"]
-- No model mentioned → preferred_models: []
+* Output valid JSON only.
 
-Priority extraction (for scoring weights - use "medium" as baseline, adjust based on context):
-- accuracy_priority: "high" if user mentions accuracy matters, quality is important, accuracy is critical, best model, or top quality. "low" if user says good enough or accuracy less important.
-- cost_priority: "high" if user EXPLICITLY says cost-effective, cost-sensitive, budget constrained, minimize cost, cost is important, or budget is tight. "low" ONLY if user EXPLICITLY says "cost doesn't matter" or "budget is unlimited" or "money is no object". Default to "medium" if not mentioned. DO NOT infer from GPU choice.
-- latency_priority: "high" if user mentions low latency needed, fast response critical, speed is important, real-time performance required, or instant responses needed. "low" if user says latency less important or async/batch is acceptable. Default to "medium" if not mentioned.
-- complexity_priority: "high" if user wants simple deployment, easy setup. "low" if they're okay with complex setups.
-IMPORTANT - Priority Extraction Rules (FOLLOW STRICTLY):
-- Only extract priorities from EXPLICIT user statements about priorities, not from hardware choices or use case type
-- Hardware preference (H100, L4, etc.) does NOT imply cost_priority - user may have GPUs available or budget allocated
-- Use case type does NOT imply latency_priority - default to "medium" unless user explicitly mentions speed/latency concerns
-- When in doubt, use "medium" - only deviate when user EXPLICITLY states a priority
-Examples:
-- "chatbot with H100" → cost_priority: "medium" (H100 doesn't mean cost doesn't matter)
-- "low latency is important" → latency_priority: "high" (explicit statement)
-- "cost-effective solution" → cost_priority: "high" (explicit statement)
-- "chatbot for 300 users, low latency important, H100 gpus" → latency_priority: "high", cost_priority: "medium" (only latency explicitly mentioned)
+USE CASE:
 
-{INTENT_EXTRACTION_SCHEMA}
-"""
+* Apply the first matching rule from this list, top to bottom.
+* If the message mentions "legal", "law", "lawyers", "attorneys", "research", or "legal analysis" => research_legal_analysis
+* If the message mentions "code generation", "full code", or "implementing features" => code_generation_detailed
+* If the message mentions "code completion" or "autocomplete" => code_completion
+* If the message mentions "chatbot", "customer service", or "conversational" => chatbot_conversational
+* If the message mentions "long document summarization" => long_document_summarization
+* If the message mentions "translation" => translation
+* If the message mentions "content generation", "marketing", or "blog" => content_generation
+* If the message mentions "summarization" => summarization_short
+* If the message mentions "RAG", "retrieval", "knowledge base", "document Q&A", or "document analysis" => document_analysis_rag
+
+USER COUNT:
+
+* Use explicit number if present.
+* Otherwise estimate an integer.
+
+DOMAIN:
+
+* Start with an empty list.
+* If use_case is code_completion or code_generation_detailed, include "code".
+* If multilingual or translation is explicitly mentioned, include "multilingual".
+* If enterprise or knowledge base is explicitly mentioned, include "enterprise".
+* If the list is empty, use ["general"].
+
+GPUs:
+
+* Extract only if explicitly mentioned.
+* "A100" => ["A100-80", "A100-40"].
+* Otherwise => [].
+
+MODELS:
+
+* Extract only if explicitly mentioned.
+* A Hugging Face model ID such as "org/model-name" is an explicit model mention.
+* If the message contains a Hugging Face model ID, copy it exactly into preferred_models.
+* If no model is explicitly mentioned => [].
+
+ACCURACY / COST / LATENCY:
+
+* Set *_mentioned = true ONLY if that topic is explicitly stated.
+* NEVER infer these fields from use_case or context.
+* If *_mentioned = false, then *_priority MUST be "medium".
+* *_priority measures importance to the user.
+* Wanting lower cost means cost_priority = "high".
+* Wanting lower latency or faster responses means latency_priority = "high".
+* Saying quality, accuracy, or correctness is critical means accuracy_priority = "high".
+* Saying a topic is unimportant, does not matter, or is not a concern means that topic's priority = "low".
+* Otherwise, when explicitly mentioned but not strongly emphasized => "medium".
+
+Return valid JSON only."""
     return prompt

--- a/src/planner/llm/prompts.py
+++ b/src/planner/llm/prompts.py
@@ -63,10 +63,12 @@ USE CASE:
 * If the message mentions "summarization" => summarization_short
 * If the message mentions "RAG", "retrieval", "knowledge base", "document Q&A", or "document analysis" => document_analysis_rag
 
-USER COUNT:
+USER COUNT (number of people who will use the system):
 
+* Count people, teams, employees, developers, attorneys, analysts, etc.
 * Use explicit number if present.
 * Otherwise estimate an integer.
+* Must be >= 1.
 
 DOMAIN:
 
@@ -78,14 +80,16 @@ DOMAIN:
 
 GPUs:
 
+* Valid GPU names: L4, A100-40, A100-80, H100, H200, B200.
 * Extract only if explicitly mentioned.
-* "A100" => ["A100-80", "A100-40"].
-* Otherwise => [].
+* "A100" (unspecified variant) => ["A100-80", "A100-40"].
+* If no GPU is explicitly mentioned => [].
 
 MODELS:
 
+* GPU names (L4, A100, H100, H200, B200) are NOT models. Never put them in preferred_models.
+* A Hugging Face model ID has the format "org/model-name" (e.g., "meta-llama/Llama-3.1-8B-Instruct").
 * Extract only if explicitly mentioned.
-* A Hugging Face model ID such as "org/model-name" is an explicit model mention.
 * If the message contains a Hugging Face model ID, copy it exactly into preferred_models.
 * If no model is explicitly mentioned => [].
 

--- a/src/planner/shared/schemas/intent.py
+++ b/src/planner/shared/schemas/intent.py
@@ -54,13 +54,6 @@ class DeploymentIntent(BaseModel):
     latency_priority: Literal["low", "medium", "high"] = Field(
         default="medium", description="Latency importance"
     )
-    complexity_priority: Literal["low", "medium", "high"] = Field(
-        default="medium", description="Preference for simpler deployments"
-    )
-
-    additional_context: str | None = Field(
-        None, description="Any other relevant details from conversation"
-    )
 
 
 class ConversationMessage(BaseModel):

--- a/tests/fixtures/intent_extraction_scenarios.json
+++ b/tests/fixtures/intent_extraction_scenarios.json
@@ -213,7 +213,7 @@
     {
       "id": "model-granite",
       "description": "IBM Granite model extraction",
-      "user_message": "Deploy IBM Granite for document analysis, 200 users",
+      "user_message": "Deploy ibm-granite/granite-3.1-8b-instruct for document analysis, 200 users",
       "conversation_history": null,
       "expected": {
         "use_case": "document_analysis_rag",
@@ -496,7 +496,7 @@
         "user_count": {"min": 10, "max": 5000},
         "domain_specialization": {"contains": ["code"]},
         "accuracy_priority": {"one_of": ["medium"]},
-        "cost_priority": {"one_of": ["medium"]},
+        "cost_priority": {"one_of": ["medium", "high"]},
         "latency_priority": {"one_of": ["medium"]}
       }
     }

--- a/tests/fixtures/intent_extraction_scenarios.json
+++ b/tests/fixtures/intent_extraction_scenarios.json
@@ -1,0 +1,504 @@
+{
+  "scenarios": [
+    {
+      "id": "uc-chatbot",
+      "description": "Basic chatbot use case",
+      "user_message": "I need a customer service chatbot for 1000 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "experience_class": {"one_of": ["conversational", "interactive"]},
+        "user_count": {"min": 500, "max": 5000},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []},
+        "accuracy_priority": {"one_of": ["medium"]},
+        "cost_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    },
+    {
+      "id": "uc-code-completion",
+      "description": "Code completion use case",
+      "user_message": "Fast code completion for 200 developers in their IDE",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "code_completion",
+        "experience_class": "instant",
+        "user_count": {"min": 100, "max": 500},
+        "domain_specialization": {"contains": ["code"]},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-code-gen",
+      "description": "Detailed code generation use case",
+      "user_message": "I need a code generation tool that produces detailed code with full explanations and documentation for 50 engineers. This is not code completion or autocomplete, it is full code_generation_detailed with long outputs.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "code_generation_detailed",
+        "experience_class": {"one_of": ["conversational", "interactive"]},
+        "user_count": {"min": 20, "max": 200},
+        "domain_specialization": {"contains": ["code"]},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-translation",
+      "description": "Translation use case",
+      "user_message": "Translation service for 300 users translating text between English, Spanish, and French",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "translation",
+        "experience_class": {"one_of": ["conversational", "interactive"]},
+        "user_count": {"min": 100, "max": 1000},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-content-gen",
+      "description": "Content generation use case",
+      "user_message": "Marketing content generation for a team of 20 content writers",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "content_generation",
+        "experience_class": {"one_of": ["conversational", "interactive"]},
+        "user_count": {"min": 10, "max": 100},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-summarization",
+      "description": "Short summarization use case",
+      "user_message": "I need short document summarization for 500 users. They will submit brief articles under 4000 tokens and need concise summaries. This is summarization_short, not a chatbot.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "summarization_short",
+        "experience_class": {"one_of": ["conversational", "interactive", "deferred"]},
+        "user_count": {"min": 200, "max": 2000},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-doc-rag",
+      "description": "Document analysis with RAG use case",
+      "user_message": "Document Q&A system with RAG for our knowledge base, 200 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "document_analysis_rag",
+        "experience_class": "interactive",
+        "user_count": {"min": 100, "max": 500},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-long-summary",
+      "description": "Long document summarization use case",
+      "user_message": "I need long document summarization for 30 analysts. They submit very long documents over 10000 tokens and need detailed summaries. Quality over speed, this is long_document_summarization not RAG.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "long_document_summarization",
+        "experience_class": {"one_of": ["deferred", "interactive", "batch"]},
+        "user_count": {"min": 10, "max": 100},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-research",
+      "description": "Research and legal analysis use case",
+      "user_message": "Research and legal analysis of regulatory documents for 10 lawyers. This is research_legal_analysis with batch processing of very long documents over 10000 tokens.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "research_legal_analysis",
+        "experience_class": {"one_of": ["batch", "deferred", "interactive"]},
+        "user_count": {"min": 5, "max": 50},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "gpu-h100",
+      "description": "H100 GPU extraction",
+      "user_message": "Deploy a chatbot for 500 users on H100 GPUs",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 200, "max": 2000},
+        "preferred_gpu_types": {"contains": ["H100"]}
+      }
+    },
+    {
+      "id": "gpu-a100",
+      "description": "A100 GPU extraction (unspecified variant)",
+      "user_message": "Code completion on A100 GPUs for 100 developers",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "code_completion",
+        "user_count": {"min": 50, "max": 500},
+        "preferred_gpu_types": {"contains_any": ["A100-40", "A100-80"]}
+      }
+    },
+    {
+      "id": "gpu-a100-80",
+      "description": "A100-80GB specific extraction",
+      "user_message": "Chatbot using A100-80GB for 200 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 100, "max": 500},
+        "preferred_gpu_types": {"contains": ["A100-80"]}
+      }
+    },
+    {
+      "id": "gpu-l4",
+      "description": "L4 GPU extraction",
+      "user_message": "Content generation on L4 GPUs, 50 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "content_generation",
+        "user_count": {"min": 20, "max": 200},
+        "preferred_gpu_types": {"contains": ["L4"]}
+      }
+    },
+    {
+      "id": "gpu-multi",
+      "description": "Multiple GPU types extraction",
+      "user_message": "Document analysis on H100 or H200, 100 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "document_analysis_rag",
+        "user_count": {"min": 50, "max": 500},
+        "preferred_gpu_types": {"contains": ["H100", "H200"]}
+      }
+    },
+    {
+      "id": "gpu-none",
+      "description": "No GPU preference",
+      "user_message": "I need a chatbot for 300 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 100, "max": 1000},
+        "preferred_gpu_types": {"exact": []}
+      }
+    },
+    {
+      "id": "model-llama",
+      "description": "Llama model extraction",
+      "user_message": "Deploy Llama 3.3 70B for chatbot with 500 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 200, "max": 2000},
+        "preferred_models": {"contains_any_partial": ["llama"]}
+      }
+    },
+    {
+      "id": "model-qwen",
+      "description": "Qwen model extraction",
+      "user_message": "Use Qwen 32B for detailed code generation with explanations, 100 developers",
+      "conversation_history": null,
+      "expected": {
+        "use_case": {"one_of": ["code_generation_detailed", "code_completion"]},
+        "user_count": {"min": 50, "max": 500},
+        "preferred_models": {"contains_any_partial": ["qwen"]}
+      }
+    },
+    {
+      "id": "model-granite",
+      "description": "IBM Granite model extraction",
+      "user_message": "Deploy IBM Granite for document analysis, 200 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "document_analysis_rag",
+        "user_count": {"min": 100, "max": 500},
+        "preferred_models": {"contains_any_partial": ["granite"]}
+      }
+    },
+    {
+      "id": "model-none",
+      "description": "No model preference",
+      "user_message": "I need a chatbot for 300 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 100, "max": 1000},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "priority-cost-high",
+      "description": "Explicit high cost priority",
+      "user_message": "Cost-effective chatbot solution for 500 users, budget is tight",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 200, "max": 2000},
+        "cost_priority": {"one_of": ["high"]}
+      }
+    },
+    {
+      "id": "priority-latency-high",
+      "description": "Explicit high latency priority",
+      "user_message": "Chatbot for 300 users, low latency is critical for us",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 100, "max": 1000},
+        "latency_priority": {"one_of": ["high"]}
+      }
+    },
+    {
+      "id": "priority-accuracy-high",
+      "description": "Explicit high accuracy priority",
+      "user_message": "I need a chatbot for 500 users, accuracy is paramount and quality must be the best possible",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 200, "max": 2000},
+        "accuracy_priority": {"one_of": ["high"]}
+      }
+    },
+    {
+      "id": "priority-defaults",
+      "description": "No explicit priorities - all should default to medium",
+      "user_message": "I need a chatbot for 200 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 100, "max": 500},
+        "accuracy_priority": {"one_of": ["medium"]},
+        "cost_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    },
+    {
+      "id": "priority-mixed",
+      "description": "Multiple explicit priorities",
+      "user_message": "Cost-effective chatbot for 1000 users, but low latency is important too",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 500, "max": 5000},
+        "cost_priority": {"one_of": ["high"]},
+        "latency_priority": {"one_of": ["high", "medium"]}
+      }
+    },
+    {
+      "id": "count-exact",
+      "description": "Exact user count",
+      "user_message": "Chatbot for exactly 500 users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 400, "max": 600}
+      }
+    },
+    {
+      "id": "count-vague",
+      "description": "Vague user count (thousands)",
+      "user_message": "Chatbot for thousands of users",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 1000, "max": 10000}
+      }
+    },
+    {
+      "id": "count-small",
+      "description": "Small team user count",
+      "user_message": "Code completion for exactly 5 developers",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "code_completion",
+        "user_count": {"min": 1, "max": 100}
+      }
+    },
+    {
+      "id": "history-gpu-refinement",
+      "description": "GPU preference from conversation history",
+      "user_message": "Use H100 GPUs",
+      "conversation_history": [
+        {"role": "user", "content": "I need a chatbot for 500 users"},
+        {"role": "assistant", "content": "I can help with that. Do you have a GPU preference?"}
+      ],
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "user_count": {"min": 200, "max": 2000},
+        "preferred_gpu_types": {"contains": ["H100"]}
+      }
+    },
+    {
+      "id": "history-context",
+      "description": "Use case from conversation history context",
+      "user_message": "It needs to do fast completions for 200 devs",
+      "conversation_history": [
+        {"role": "user", "content": "I'm building a code tool for my engineering team"},
+        {"role": "assistant", "content": "Great! Tell me more about what kind of code tool you need."}
+      ],
+      "expected": {
+        "use_case": "code_completion",
+        "user_count": {"min": 100, "max": 500}
+      }
+    },
+    {
+      "id": "edge-ambiguous",
+      "description": "Ambiguous request - should still return valid intent",
+      "user_message": "I need an AI system for my team of 50",
+      "conversation_history": null,
+      "expected": {
+        "user_count": {"min": 20, "max": 200}
+      }
+    },
+    {
+      "id": "ui-btn-chat-completion",
+      "description": "UI task button: Chat Completion",
+      "user_message": "Customer service chatbot for 30 users.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "chatbot_conversational",
+        "experience_class": {"one_of": ["conversational", "interactive"]},
+        "user_count": {"min": 10, "max": 100},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []},
+        "accuracy_priority": {"one_of": ["medium"]},
+        "cost_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    },
+    {
+      "id": "ui-btn-code-completion",
+      "description": "UI task button: Code Completion",
+      "user_message": "IDE code completion tool for 300 developers.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "code_completion",
+        "experience_class": {"one_of": ["instant", "conversational"]},
+        "user_count": {"min": 100, "max": 1000},
+        "domain_specialization": {"contains": ["code"]},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []},
+        "accuracy_priority": {"one_of": ["medium"]},
+        "cost_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    },
+    {
+      "id": "ui-btn-doc-qa",
+      "description": "UI task button: Document Q&A",
+      "user_message": "Document Q&A system for enterprise knowledge base, 300 users.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "document_analysis_rag",
+        "experience_class": {"one_of": ["interactive", "conversational"]},
+        "user_count": {"min": 100, "max": 1000},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []},
+        "accuracy_priority": {"one_of": ["medium"]},
+        "cost_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    },
+    {
+      "id": "ui-btn-summarization",
+      "description": "UI task button: Summarization (explicit cost priority)",
+      "user_message": "News article summarization for 300 users, cost-effective solution preferred.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "summarization_short",
+        "experience_class": {"one_of": ["conversational", "interactive"]},
+        "user_count": {"min": 100, "max": 1000},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []},
+        "cost_priority": {"one_of": ["high"]},
+        "accuracy_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    },
+    {
+      "id": "ui-btn-legal-analysis",
+      "description": "UI task button: Legal Analysis (explicit accuracy priority)",
+      "user_message": "Legal document analysis for 300 lawyers, accuracy is critical.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "research_legal_analysis",
+        "experience_class": {"one_of": ["batch", "deferred", "interactive"]},
+        "user_count": {"min": 100, "max": 1000},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []},
+        "accuracy_priority": {"one_of": ["high"]},
+        "cost_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    },
+    {
+      "id": "ui-btn-translation",
+      "description": "UI task button: Translation",
+      "user_message": "Multi-language translation service for 300 users.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "translation",
+        "experience_class": {"one_of": ["conversational", "interactive"]},
+        "user_count": {"min": 100, "max": 1000},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []},
+        "accuracy_priority": {"one_of": ["medium"]},
+        "cost_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    },
+    {
+      "id": "ui-btn-content-generation",
+      "description": "UI task button: Content Generation",
+      "user_message": "Content generation tool for marketing team, 300 users.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "content_generation",
+        "experience_class": {"one_of": ["conversational", "interactive"]},
+        "user_count": {"min": 100, "max": 1000},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []},
+        "accuracy_priority": {"one_of": ["medium"]},
+        "cost_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    },
+    {
+      "id": "ui-btn-long-doc-summary",
+      "description": "UI task button: Long Doc Summary (explicit accuracy priority)",
+      "user_message": "Long document summarization for research papers, 30 researchers, accuracy matters.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "long_document_summarization",
+        "experience_class": {"one_of": ["deferred", "interactive", "batch"]},
+        "user_count": {"min": 10, "max": 100},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []},
+        "accuracy_priority": {"one_of": ["high"]},
+        "cost_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    },
+    {
+      "id": "ui-btn-code-generation",
+      "description": "UI task button: Code Generation",
+      "user_message": "Full code generation tool for implementing features, 30 developers.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "code_generation_detailed",
+        "experience_class": {"one_of": ["conversational", "interactive"]},
+        "user_count": {"min": 10, "max": 5000},
+        "domain_specialization": {"contains": ["code"]},
+        "accuracy_priority": {"one_of": ["medium"]},
+        "cost_priority": {"one_of": ["medium"]},
+        "latency_priority": {"one_of": ["medium"]}
+      }
+    }
+  ]
+}

--- a/tests/fixtures/intent_extraction_scenarios.json
+++ b/tests/fixtures/intent_extraction_scenarios.json
@@ -32,7 +32,21 @@
     },
     {
       "id": "uc-code-gen",
-      "description": "Detailed code generation use case",
+      "description": "Detailed code generation (natural language)",
+      "user_message": "I need a tool that writes complete functions and classes with full docstrings and explanations for 50 engineers. Not autocomplete — we want it to generate entire modules from a description.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "code_generation_detailed",
+        "experience_class": {"one_of": ["conversational", "interactive"]},
+        "user_count": {"min": 20, "max": 200},
+        "domain_specialization": {"contains": ["code"]},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-code-gen-explicit",
+      "description": "Detailed code generation (explicit enum — sanity test)",
       "user_message": "I need a code generation tool that produces detailed code with full explanations and documentation for 50 engineers. This is not code completion or autocomplete, it is full code_generation_detailed with long outputs.",
       "conversation_history": null,
       "expected": {
@@ -72,7 +86,20 @@
     },
     {
       "id": "uc-summarization",
-      "description": "Short summarization use case",
+      "description": "Short summarization (natural language)",
+      "user_message": "We need to summarize short news articles and blog posts into a few bullet points for 500 users. Articles are typically under a page long and we want quick, concise summaries.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "summarization_short",
+        "experience_class": {"one_of": ["conversational", "interactive", "deferred"]},
+        "user_count": {"min": 200, "max": 2000},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-summarization-explicit",
+      "description": "Short summarization (explicit enum — sanity test)",
       "user_message": "I need short document summarization for 500 users. They will submit brief articles under 4000 tokens and need concise summaries. This is summarization_short, not a chatbot.",
       "conversation_history": null,
       "expected": {
@@ -98,7 +125,20 @@
     },
     {
       "id": "uc-long-summary",
-      "description": "Long document summarization use case",
+      "description": "Long document summarization (natural language)",
+      "user_message": "Our 30 analysts need to condense lengthy research reports and white papers — often 50+ pages — into comprehensive executive summaries. Thoroughness matters more than speed.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "long_document_summarization",
+        "experience_class": {"one_of": ["deferred", "interactive", "batch"]},
+        "user_count": {"min": 10, "max": 100},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-long-summary-explicit",
+      "description": "Long document summarization (explicit enum — sanity test)",
       "user_message": "I need long document summarization for 30 analysts. They submit very long documents over 10000 tokens and need detailed summaries. Quality over speed, this is long_document_summarization not RAG.",
       "conversation_history": null,
       "expected": {
@@ -111,7 +151,20 @@
     },
     {
       "id": "uc-research",
-      "description": "Research and legal analysis use case",
+      "description": "Research and legal analysis (natural language)",
+      "user_message": "Our legal team of 10 attorneys needs to analyze lengthy regulatory filings and case law to extract relevant precedents and compliance requirements. They process very large documents and can wait for results.",
+      "conversation_history": null,
+      "expected": {
+        "use_case": "research_legal_analysis",
+        "experience_class": {"one_of": ["batch", "deferred", "interactive"]},
+        "user_count": {"min": 5, "max": 50},
+        "preferred_gpu_types": {"exact": []},
+        "preferred_models": {"exact": []}
+      }
+    },
+    {
+      "id": "uc-research-explicit",
+      "description": "Research and legal analysis (explicit enum — sanity test)",
       "user_message": "Research and legal analysis of regulatory documents for 10 lawyers. This is research_legal_analysis with batch processing of very long documents over 10000 tokens.",
       "conversation_history": null,
       "expected": {

--- a/tests/intent_extraction/conftest.py
+++ b/tests/intent_extraction/conftest.py
@@ -1,0 +1,124 @@
+"""Fixtures and helpers for intent extraction tests."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from planner.intent_extraction.extractor import IntentExtractor
+from planner.llm.ollama_client import OllamaClient
+from planner.shared.schemas import DeploymentIntent
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def ollama_client():
+    """Create OllamaClient, skipping all tests if Ollama is not available."""
+    client = OllamaClient()
+    if not client.is_available():
+        pytest.skip("Ollama service is not available — skipping intent extraction tests")
+    return client
+
+
+@pytest.fixture(scope="session")
+def intent_extractor(ollama_client):
+    """Create IntentExtractor with a verified OllamaClient."""
+    return IntentExtractor(llm_client=ollama_client)
+
+
+def assert_intent_matches(intent: DeploymentIntent, expected: dict) -> None:
+    """Validate a DeploymentIntent against flexible expected values.
+
+    Supported matchers per field type:
+      - str fields (use_case, experience_class):
+          plain string              — exact match
+          {"one_of": [...]}         — value must be in the list
+      - user_count: {"min": N, "max": M} range check
+      - list fields (domain_specialization, preferred_gpu_types, preferred_models):
+          {"exact": [...]}           — sorted equality
+          {"contains": [...]}        — all items must be present
+          {"contains_any": [...]}    — at least one item must be present
+          {"contains_any_partial": [...]} — at least one item partially matches
+                                           (case-insensitive substring)
+      - priority fields: {"one_of": [...]} — value must be in the list
+    """
+    # use_case: exact match or one_of
+    if "use_case" in expected:
+        exp = expected["use_case"]
+        if isinstance(exp, dict) and "one_of" in exp:
+            assert intent.use_case in exp["one_of"], (
+                f"use_case: got '{intent.use_case}', expected one of {exp['one_of']}"
+            )
+        else:
+            assert intent.use_case == exp, f"use_case: got '{intent.use_case}', expected '{exp}'"
+
+    # experience_class: exact match or one_of
+    if "experience_class" in expected:
+        exp = expected["experience_class"]
+        if isinstance(exp, dict) and "one_of" in exp:
+            assert intent.experience_class in exp["one_of"], (
+                f"experience_class: got '{intent.experience_class}', "
+                f"expected one of {exp['one_of']}"
+            )
+        else:
+            assert intent.experience_class == exp, (
+                f"experience_class: got '{intent.experience_class}', expected '{exp}'"
+            )
+
+    # user_count: range check
+    if "user_count" in expected:
+        spec = expected["user_count"]
+        assert spec["min"] <= intent.user_count <= spec["max"], (
+            f"user_count: got {intent.user_count}, expected range [{spec['min']}, {spec['max']}]"
+        )
+
+    # List fields
+    for field in ["domain_specialization", "preferred_gpu_types", "preferred_models"]:
+        if field not in expected:
+            continue
+        spec = expected[field]
+        actual: list[str] = getattr(intent, field)
+
+        if "exact" in spec:
+            assert sorted(actual) == sorted(spec["exact"]), (
+                f"{field}: got {actual}, expected exactly {spec['exact']}"
+            )
+
+        if "contains" in spec:
+            for item in spec["contains"]:
+                assert item in actual, f"{field}: expected '{item}' in {actual}"
+
+        if "contains_any" in spec:
+            assert any(item in actual for item in spec["contains_any"]), (
+                f"{field}: expected any of {spec['contains_any']} in {actual}"
+            )
+
+        if "contains_any_partial" in spec:
+            # Case-insensitive substring match: at least one actual item
+            # must contain one of the expected substrings.
+            lower_actual = [a.lower() for a in actual]
+            matched = any(
+                substr.lower() in a for substr in spec["contains_any_partial"] for a in lower_actual
+            )
+            assert matched, (
+                f"{field}: expected any of {spec['contains_any_partial']} "
+                f"(case-insensitive partial) in {actual}"
+            )
+
+    # Priority fields
+    for field in [
+        "accuracy_priority",
+        "cost_priority",
+        "latency_priority",
+    ]:
+        if field not in expected:
+            continue
+        spec = expected[field]
+        actual_val: str = getattr(intent, field)
+
+        if "one_of" in spec:
+            assert actual_val in spec["one_of"], (
+                f"{field}: got '{actual_val}', expected one of {spec['one_of']}"
+            )

--- a/tests/intent_extraction/test_intent_extraction.py
+++ b/tests/intent_extraction/test_intent_extraction.py
@@ -1,0 +1,41 @@
+"""Full intent extraction test suite.
+
+Parametrized from tests/fixtures/intent_extraction_scenarios.json.
+Run explicitly with: make test-intent
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from planner.shared.schemas import ConversationMessage
+
+from .conftest import assert_intent_matches
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+def _load_scenarios():
+    """Load test scenarios from JSON fixture file."""
+    with open(FIXTURES_DIR / "intent_extraction_scenarios.json") as f:
+        return json.load(f)["scenarios"]
+
+
+@pytest.mark.intent_extraction
+@pytest.mark.parametrize("scenario", _load_scenarios(), ids=lambda s: s["id"])
+def test_intent_extraction(intent_extractor, scenario):
+    """Test that intent extraction produces expected results for each scenario."""
+    # Build conversation history if provided
+    history = None
+    if scenario.get("conversation_history"):
+        history = [ConversationMessage(**msg) for msg in scenario["conversation_history"]]
+
+    intent = intent_extractor.extract_intent(
+        user_message=scenario["user_message"],
+        conversation_history=history,
+    )
+
+    assert_intent_matches(intent, scenario["expected"])

--- a/tests/intent_extraction/test_intent_extraction_smoke.py
+++ b/tests/intent_extraction/test_intent_extraction_smoke.py
@@ -1,0 +1,29 @@
+"""Smoke tests for intent extraction.
+
+These run as part of ``make test-integration`` (and therefore ``make test``)
+to catch basic regressions without running the full scenario suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+def test_smoke_chatbot_extraction(intent_extractor):
+    """Smoke test: basic chatbot intent extraction works."""
+    intent = intent_extractor.extract_intent("I need a chatbot for 500 users")
+
+    assert intent.use_case == "chatbot_conversational"
+    assert intent.experience_class == "conversational"
+    assert intent.user_count > 0
+
+
+@pytest.mark.integration
+def test_smoke_code_completion_extraction(intent_extractor):
+    """Smoke test: basic code completion intent extraction works."""
+    intent = intent_extractor.extract_intent("Fast code completion for 100 developers")
+
+    assert intent.use_case == "code_completion"
+    assert intent.experience_class == "instant"
+    assert intent.user_count > 0

--- a/tests/test_yaml_generation.py
+++ b/tests/test_yaml_generation.py
@@ -34,7 +34,6 @@ def create_test_recommendation() -> DeploymentRecommendation:
         experience_class="conversational",
         user_count=5000,
         domain_specialization=["general"],
-        additional_context=None,
     )
 
     traffic_profile = TrafficProfile(prompt_tokens=512, output_tokens=256, expected_qps=50.0)

--- a/tests/unit/test_config_finder_cluster_gpus.py
+++ b/tests/unit/test_config_finder_cluster_gpus.py
@@ -17,7 +17,6 @@ def _make_intent(
         experience_class="conversational",
         user_count=100,
         preferred_gpu_types=preferred_gpu_types or [],
-        additional_context=None,
     )
 
 

--- a/tests/unit/test_config_finder_quality_scorer.py
+++ b/tests/unit/test_config_finder_quality_scorer.py
@@ -52,7 +52,6 @@ def _make_intent(use_case: str = "chatbot_conversational") -> DeploymentIntent:
         use_case=use_case,  # type: ignore[arg-type]
         user_count=100,
         experience_class="conversational",
-        additional_context=None,
     )
 
 

--- a/tests/unit/test_estimated_performance.py
+++ b/tests/unit/test_estimated_performance.py
@@ -25,7 +25,6 @@ def _make_intent(
         user_count=100,
         preferred_gpu_types=preferred_gpu_types or [],
         preferred_models=preferred_models or [],
-        additional_context=None,
     )
 
 

--- a/tests/unit/test_intent_extractor.py
+++ b/tests/unit/test_intent_extractor.py
@@ -21,7 +21,6 @@ def _base_intent(**overrides) -> dict:
         "accuracy_priority": "medium",
         "cost_priority": "medium",
         "latency_priority": "medium",
-        "complexity_priority": "medium",
     }
     data.update(overrides)
     return data
@@ -96,6 +95,26 @@ def test_clean_llm_output_preserves_valid_use_case(extractor, valid_use_case):
 def test_clean_llm_output_fuzzy_matches_close_typos(extractor, typo, expected):
     """Typos close to valid values are fuzzy-matched."""
     raw = _base_intent(use_case=typo)
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned["use_case"] == expected
+
+
+# --- Case-insensitive normalization ---
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "mixed_case, expected",
+    [
+        ("Text_Summarization", "summarization_short"),
+        ("CHATBOT", "chatbot_conversational"),
+        ("Code_Completion", "code_completion"),
+        ("DOCUMENT_ANALYSIS_RAG", "document_analysis_rag"),
+    ],
+)
+def test_clean_llm_output_handles_case_insensitive(extractor, mixed_case, expected):
+    """Mixed-case use_case values are lowercased before alias/fuzzy matching."""
+    raw = _base_intent(use_case=mixed_case)
     cleaned = extractor._clean_llm_output(raw)
     assert cleaned["use_case"] == expected
 

--- a/tests/unit/test_intent_extractor.py
+++ b/tests/unit/test_intent_extractor.py
@@ -131,6 +131,153 @@ def test_clean_llm_output_does_not_match_garbage(extractor, garbage):
     assert cleaned["use_case"] == garbage
 
 
+# --- *_mentioned gating of priorities ---
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prefix", ["accuracy", "cost", "latency"])
+def test_mentioned_true_preserves_priority(extractor, prefix):
+    """When *_mentioned is true, the LLM's priority is kept."""
+    raw = _base_intent(
+        **{
+            f"{prefix}_priority": "high",
+            f"{prefix}_mentioned": True,
+        }
+    )
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned[f"{prefix}_priority"] == "high"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prefix", ["accuracy", "cost", "latency"])
+def test_mentioned_false_resets_non_medium_priority(extractor, prefix):
+    """When *_mentioned is false, a non-medium priority is forced to medium."""
+    raw = _base_intent(
+        **{
+            f"{prefix}_priority": "high",
+            f"{prefix}_mentioned": False,
+        }
+    )
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned[f"{prefix}_priority"] == "medium"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prefix", ["accuracy", "cost", "latency"])
+def test_mentioned_false_keeps_medium_priority(extractor, prefix):
+    """When *_mentioned is false but priority is already medium, no change needed."""
+    raw = _base_intent(
+        **{
+            f"{prefix}_priority": "medium",
+            f"{prefix}_mentioned": False,
+        }
+    )
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned[f"{prefix}_priority"] == "medium"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prefix", ["accuracy", "cost", "latency"])
+def test_mentioned_missing_defaults_to_trust(extractor, prefix):
+    """When *_mentioned is absent, the priority is trusted (default True)."""
+    raw = _base_intent(**{f"{prefix}_priority": "high"})
+    assert f"{prefix}_mentioned" not in raw
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned[f"{prefix}_priority"] == "high"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prefix", ["accuracy", "cost", "latency"])
+def test_mentioned_string_true_preserves_priority(extractor, prefix):
+    """String 'true' is parsed correctly as truthy."""
+    raw = _base_intent(
+        **{
+            f"{prefix}_priority": "high",
+            f"{prefix}_mentioned": "true",
+        }
+    )
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned[f"{prefix}_priority"] == "high"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prefix", ["accuracy", "cost", "latency"])
+def test_mentioned_string_false_resets_priority(extractor, prefix):
+    """String 'false' is parsed correctly as falsy."""
+    raw = _base_intent(
+        **{
+            f"{prefix}_priority": "high",
+            f"{prefix}_mentioned": "false",
+        }
+    )
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned[f"{prefix}_priority"] == "medium"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prefix", ["accuracy", "cost", "latency"])
+def test_mentioned_string_False_case_insensitive(extractor, prefix):
+    """String 'False' (capitalized) is treated as falsy."""
+    raw = _base_intent(
+        **{
+            f"{prefix}_priority": "low",
+            f"{prefix}_mentioned": "False",
+        }
+    )
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned[f"{prefix}_priority"] == "medium"
+
+
+@pytest.mark.unit
+def test_mentioned_fields_not_in_cleaned_output(extractor):
+    """*_mentioned fields are consumed and not passed through to the final dict."""
+    raw = _base_intent(
+        accuracy_mentioned=True,
+        cost_mentioned=False,
+        latency_mentioned=True,
+    )
+    cleaned = extractor._clean_llm_output(raw)
+    for prefix in ("accuracy", "cost", "latency"):
+        assert f"{prefix}_mentioned" not in cleaned
+
+
+@pytest.mark.unit
+def test_mentioned_false_resets_multiple_priorities(extractor):
+    """All three priorities can be independently gated by their *_mentioned flags."""
+    raw = _base_intent(
+        accuracy_priority="high",
+        accuracy_mentioned=True,
+        cost_priority="low",
+        cost_mentioned=False,
+        latency_priority="high",
+        latency_mentioned=False,
+    )
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned["accuracy_priority"] == "high"
+    assert cleaned["cost_priority"] == "medium"
+    assert cleaned["latency_priority"] == "medium"
+
+
+# --- user_count=0 guard ---
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad_count", [0, -1, -100])
+def test_user_count_zero_or_negative_defaults_to_1000(extractor, bad_count):
+    """user_count <= 0 (LLM schema default echo) is replaced with 100."""
+    raw = _base_intent(user_count=bad_count)
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned["user_count"] == 100
+
+
+@pytest.mark.unit
+def test_user_count_positive_preserved(extractor):
+    """A valid positive user_count is kept as-is."""
+    raw = _base_intent(user_count=10)
+    cleaned = extractor._clean_llm_output(raw)
+    assert cleaned["user_count"] == 10
+
+
 # --- Integration: full parse with mocked hallucinated value ---
 
 

--- a/tests/unit/test_workflow_gpu_detection.py
+++ b/tests/unit/test_workflow_gpu_detection.py
@@ -94,7 +94,6 @@ class TestWorkflowGPUDetection:
             experience_class="conversational",
             user_count=100,
             preferred_gpu_types=[],
-            additional_context=None,
         )
         traffic = TrafficProfile(prompt_tokens=512, output_tokens=256, expected_qps=5.0)
         slo = SLOTargets(ttft_p95_target_ms=500, itl_p95_target_ms=50, e2e_p95_target_ms=15000)


### PR DESCRIPTION
- Add 39-scenario test suite for LLM intent extraction covering all 9 use cases, GPU/model extraction, priority enforcement, user counts, conversation history, and UI button strings. Run explicitly via make test-intent (requires Ollama); 2 smoke tests run as part of make test-integration.

- Rewrite the intent extraction prompt as a short, directive format with ordered pattern-matching rules, replacing the verbose prose prompt. Remove experience_class, complexity_priority, and additional_context from the prompt — fields that were either inferred deterministically or never consumed downstream. Consolidate the prompt as self-contained (remove INTENT_EXTRACTION_SCHEMA constant and schema_description parameter from extract_structured_data).

- Fix unreliable priority extraction: the LLM (qwen2.5:7b) was inferring priorities from use case type rather than from explicit user statements, causing incorrect scoring weights. The LLM now returns *_mentioned booleans alongside *_priority values, and post-processing resets priority to "medium" when the topic was not explicitly mentioned.

- Harden post-processing: case-insensitive normalization for domain_specialization, experience_class, use_case, and *_mentioned booleans; priority value aliases (e.g. "very_high" -> "high") applied before validation; logger.warning when an unrecognized use_case cannot be resolved by alias map or fuzzy match. Add 4 unit tests for case-insensitive normalization.