### PR TITLE
docs: remove obsolete note referencing deleted file

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+MAPE = "MAPE"  # Mean Absolute Percentage Error

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,10 +1,5 @@
 # Planner Architecture
 
-> **Note**: This document replaces the original
-> [ARCHITECTUREv1.md](archive/ARCHITECTUREv1.md) document that captured our
-> initial design thinking. This revision reflects the production architecture
-> vision that emerged after completing the POC.
-
 ## Overview
 
 ### Vision


### PR DESCRIPTION
Removes note block in ARCHITECTURE.md that references the deleted archive/ARCHITECTUREv1.md file.
Adds typos configuration to prevent false positives for MAPE.

Fixes #123