### PR TITLE
fix: include model_uri column in benchmark data loader INSERT query

### DIFF
--- a/src/planner/knowledge_base/loader.py
+++ b/src/planner/knowledge_base/loader.py
@@ -113,6 +113,7 @@ def prepare_benchmark_for_insert(
     prepared.setdefault("profiler_type", None)
     prepared.setdefault("profiler_image", None)
     prepared.setdefault("profiler_tag", None)
+    prepared.setdefault("model_uri", None)
     prepared["source"] = source
     prepared["confidence_level"] = confidence_level
 
@@ -136,7 +137,7 @@ _INSERT_QUERY = """
         prompt_tokens, prompt_tokens_stdev, prompt_tokens_min, prompt_tokens_max,
         output_tokens, output_tokens_min, output_tokens_max, output_tokens_stdev,
         profiler_type, profiler_image, profiler_tag,
-        source, confidence_level
+        source, confidence_level, model_uri
     ) VALUES (
         %(id)s, %(config_id)s, %(model_hf_repo)s, %(provider)s, %(type)s,
         %(ttft_mean)s, %(ttft_p90)s, %(ttft_p95)s, %(ttft_p99)s,
@@ -152,7 +153,7 @@ _INSERT_QUERY = """
         %(prompt_tokens)s, %(prompt_tokens_stdev)s, %(prompt_tokens_min)s, %(prompt_tokens_max)s,
         %(output_tokens)s, %(output_tokens_min)s, %(output_tokens_max)s, %(output_tokens_stdev)s,
         %(profiler_type)s, %(profiler_image)s, %(profiler_tag)s,
-        %(source)s, %(confidence_level)s
+        %(source)s, %(confidence_level)s, %(model_uri)s
     )
     ON CONFLICT (config_id) DO NOTHING;
 """


### PR DESCRIPTION
## Description

The `_INSERT_QUERY` in `src/planner/knowledge_base/loader.py` was missing the `model_uri` column. This caused benchmark records loaded with a `model_uri` value (_e.g._, an OCI registry URI like `oci://registry.redhat.io/...`) to silently drop it during database insertion.

As a result, the `deploy_model` flow could not resolve the model's storage location from the database, even when the source JSON data included `model_uri`. The deployment would then prompt the user for a storage URI that should have already been available.

**Changes:**
- Added `model_uri` to the column list and `VALUES` clause in `_INSERT_QUERY`
- Added `prepared.setdefault("model_uri", None)` in `prepare_benchmark_for_insert` so records without a `model_uri` default to `NULL` instead of raising a `KeyError`

## How Has This Been Tested?

- All 189 existing unit tests pass (`uv run pytest tests/unit/ -q`)
- Manually verified on an OpenShift cluster (namespace `neuralnav`) by:
  1. Loading benchmark data containing `model_uri` values via the `/api/v1/db/load` endpoint
  2. Querying the database to confirm `model_uri` was persisted in `exported_summaries`
  3. Running a recommendation-to-deployment flow and confirming the generated YAML included the correct `storageUri` from the database

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work