### PR TITLE
chore: add pull request template (same as ODH's)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Merge criteria:
+<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+
+- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
+- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
+- [ ] The developer has manually tested the changes and verified that the changes work


### PR DESCRIPTION
Copy the pull request template from [opendatahub-io's .github repo](https://github.com/opendatahub-io/.github): _[PULL_REQUEST_TEMPLATE.md](https://github.com/opendatahub-io/.github/blob/main/PULL_REQUEST_TEMPLATE.md)_ and use it in our repository as the official pull request template.