### PR TITLE
Update visual design and interactions on recommendations tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,12 @@ uv.lock
 *~
 .DS_Store
 
+# Design context, rationale, and history
+.design/
+
+# Repo-specific rules and skills
+.agents/
+
 # Testing
 .pytest_cache/
 .coverage

--- a/ui/app.py
+++ b/ui/app.py
@@ -75,7 +75,7 @@ init_session_state()
 
 def render_hero():
     """Render compact hero section with logo."""
-    logo_col, title_col = st.columns([1, 11], vertical_alignment="center")
+    logo_col, title_col = st.columns([0.4, 11.6], vertical_alignment="center", gap="small")
     with logo_col:
         st.image("ui/static/planner-logo.png", width=48)
     with title_col:
@@ -118,7 +118,7 @@ def render_use_case_input_tab(priority: str, models_df: pd.DataFrame):
     )
 
     # Row 1: 5 task buttons
-    col1, col2, col3, col4, col5 = st.columns(5)
+    col1, col2, col3, col4, col5 = st.columns(5, gap="medium")
 
     with col1:
         if st.button("Chat Completion", width="stretch", key="task_chat"):
@@ -157,7 +157,7 @@ def render_use_case_input_tab(priority: str, models_df: pd.DataFrame):
             st.rerun()
 
     # Row 2: 4 more task buttons
-    col6, col7, col8, col9 = st.columns(4)
+    col6, col7, col8, col9 = st.columns(4, gap="medium")
 
     with col6:
         if st.button("Translation", width="stretch", key="task_trans"):
@@ -198,7 +198,7 @@ def render_use_case_input_tab(priority: str, models_df: pd.DataFrame):
         unsafe_allow_html=True,
     )
 
-    col1, col2, col3 = st.columns([1.5, 1, 2])
+    col1, col2, col3 = st.columns([1.5, 1, 2], gap="medium")
     with col1:
         analyze_disabled = (
             len(st.session_state.user_input.strip()) < 10 if st.session_state.user_input else True

--- a/ui/app.py
+++ b/ui/app.py
@@ -57,6 +57,29 @@ st.markdown(
     .block-container { padding-top: 0 !important; }
     /* Transparent header so menu appears inline with content */
     header[data-testid="stHeader"] { background: transparent; }
+    /* Hero: logo stays 48px; column ratios were shrinking the image with the window */
+    .planner-hero-title-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: nowrap;
+    }
+    .planner-hero-title-row img {
+        width: 48px !important;
+        height: 48px !important;
+        max-width: 48px !important;
+        min-width: 48px !important;
+        flex-shrink: 0 !important;
+        object-fit: contain;
+    }
+    .planner-hero-title-row h1 {
+        margin: 0;
+        padding: 0;
+        font-size: 2.75rem;
+        font-weight: 600;
+        line-height: 1.15;
+        border: none;
+    }
 </style>
 """,
     unsafe_allow_html=True,
@@ -74,12 +97,20 @@ init_session_state()
 
 
 def render_hero():
-    """Render compact hero section with logo."""
-    logo_col, title_col = st.columns([0.4, 11.6], vertical_alignment="center", gap="small")
-    with logo_col:
-        st.image("ui/static/planner-logo.png", width=48)
-    with title_col:
-        st.title("Planner")
+    """Render compact hero section with logo.
+
+    Logo uses /app/static/ (see .streamlit/config.toml enableStaticServing) so it
+    stays a fixed 48px; st.columns + st.image was scaling the image with viewport.
+    """
+    st.markdown(
+        """
+<div class="planner-hero-title-row">
+    <img src="/app/static/planner-logo.png" width="48" height="48" alt="Planner logo" />
+    <h1>Planner</h1>
+</div>
+""",
+        unsafe_allow_html=True,
+    )
     st.caption(
         "AI-Powered LLM Deployment Recommendations — From Natural Language to Production in Seconds"
     )

--- a/ui/app.py
+++ b/ui/app.py
@@ -75,7 +75,7 @@ st.markdown(
     .planner-hero-title-row h1 {
         margin: 0;
         padding: 0;
-        font-size: 2.75rem;
+        font-size: 2rem;
         font-weight: 600;
         line-height: 1.15;
         border: none;

--- a/ui/components/deployment.py
+++ b/ui/components/deployment.py
@@ -38,7 +38,7 @@ def render_deployment_tab():
 
     st.markdown(
         f"""
-    <div style="border-radius: 12px; padding: 1rem; margin-bottom: 1.5rem;">
+    <div style="border-radius: 12px; margin-bottom: 1.5rem;">
         <div style="display: flex; align-items: center; gap: 2rem; flex-wrap: wrap;">
             <div>
                 <span style="font-size: 0.85rem;">Model:</span>

--- a/ui/components/deployment_management.py
+++ b/ui/components/deployment_management.py
@@ -109,7 +109,7 @@ def _render_deployment_controls(deployment_info: dict):
 
     st.markdown("#### Deployment Management")
 
-    col1, col2, col3 = st.columns(3)
+    col1, col2, col3 = st.columns(3, gap="medium")
 
     with col1:
         ready_status = "Ready" if status.get("ready") else "Pending"
@@ -292,7 +292,7 @@ def _run_inference_test(deployment_id: str, prompt: str, max_tokens: int, temper
                     st.code(response_text, language=None)
 
                     usage = response_data.get("usage", {})
-                    c1, c2, c3 = st.columns(3)
+                    c1, c2, c3 = st.columns(3, gap="medium")
                     with c1:
                         st.metric("Prompt Tokens", usage.get("prompt_tokens", 0))
                     with c2:

--- a/ui/components/extraction.py
+++ b/ui/components/extraction.py
@@ -77,7 +77,7 @@ def render_extraction_with_approval(extraction: dict, models_df):
         f"**Priorities:** {priorities}"
     )
 
-    col1, col2, col3 = st.columns([1, 1, 1])
+    col1, col2, col3 = st.columns([1, 1, 1], gap="medium")
     with col1:
         if st.button(
             "Generate Specification",
@@ -142,7 +142,7 @@ def render_extraction_edit_form(extraction: dict, models_df):
     current_use_case = extraction.get("use_case", "chatbot_conversational")
     current_idx = use_cases.index(current_use_case) if current_use_case in use_cases else 0
 
-    col1, col2 = st.columns(2)
+    col1, col2 = st.columns(2, gap="medium")
     with col1:
         new_use_case = st.selectbox(
             "Use Case",
@@ -198,7 +198,7 @@ def render_extraction_edit_form(extraction: dict, models_df):
 
     # Model selection
     st.markdown("**Model Preferences** (optional)")
-    col_models, col_custom = st.columns(2)
+    col_models, col_custom = st.columns(2, gap="medium")
     with col_models:
         # Get catalog models for multiselect
         catalog_model_ids = fetch_catalog_model_ids()
@@ -227,7 +227,7 @@ def render_extraction_edit_form(extraction: dict, models_df):
 
     st.markdown("<br>", unsafe_allow_html=True)
 
-    col1, col2 = st.columns(2)
+    col1, col2 = st.columns(2, gap="medium")
     with col1:
         if st.button("Apply Changes", type="primary", width="stretch", key="apply_edit"):
             edited = {

--- a/ui/components/recommendations.py
+++ b/ui/components/recommendations.py
@@ -532,7 +532,7 @@ def render_recommendation_result(result: dict, priority: str, extraction: dict):
                 "View Deployment Configuration",
                 key="view_deployment_config_btn",
                 use_container_width=True,
-                type="primary"
+                type="primary",
             ):
                 # Navigate to Deployment tab (index 3)
                 st.session_state["_pending_tab"] = 3
@@ -542,7 +542,7 @@ def render_recommendation_result(result: dict, priority: str, extraction: dict):
                 "View Deployment Configuration",
                 key="view_deployment_config_btn_disabled",
                 use_container_width=True,
-                disabled=True
+                disabled=True,
             )
 
     # === CONFIGURATION OPTIONS SECTION ===

--- a/ui/components/recommendations.py
+++ b/ui/components/recommendations.py
@@ -132,47 +132,42 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
             unsafe_allow_html=True,
         )
 
-        # Prev/Next navigation (circular) - compact centered layout
+        # Prev/Next navigation (circular) - simplified responsive layout
         if len(recs_list) > 1:
             last = len(recs_list) - 1
 
-            # Use narrow columns for compact centered navigation
-            spacer_l, nav_area, spacer_r = st.columns([0.3, 0.4, 0.3])
-            with nav_area:
-                btn_prev, counter, btn_next = st.columns([1, 1.5, 1])
-                with btn_prev:
-                    # Right-align the prev button using nested columns
-                    empty, btn = st.columns([0.3, 0.7])
-                    with btn:
-                        if st.button("◀", key=f"prev_{category_key}"):
-                            st.session_state[idx_key] = last if idx == 0 else idx - 1
-                            st.session_state.deployment_selected_config = None
-                            st.session_state.deployment_selected_category = None
-                            st.session_state.deployment_yaml_generated = False
-                            st.session_state.deployment_yaml_files = {}
-                            st.session_state.deployment_id = None
-                            st.session_state.deployment_error = None
-                            st.session_state.deployed_to_cluster = False
-                            st.rerun()
-                with counter:
-                    st.markdown(
-                        f"<div style='text-align: center; line-height: 2.4; font-size: 0.85rem;'>#{idx + 1} of {len(recs_list)}</div>",
-                        unsafe_allow_html=True,
-                    )
-                with btn_next:
-                    # Left-align but add spacing with nested columns
-                    btn, empty = st.columns([0.7, 0.3])
-                    with btn:
-                        if st.button("▶", key=f"next_{category_key}"):
-                            st.session_state[idx_key] = 0 if idx == last else idx + 1
-                            st.session_state.deployment_selected_config = None
-                            st.session_state.deployment_selected_category = None
-                            st.session_state.deployment_yaml_generated = False
-                            st.session_state.deployment_yaml_files = {}
-                            st.session_state.deployment_id = None
-                            st.session_state.deployment_error = None
-                            st.session_state.deployed_to_cluster = False
-                            st.rerun()
+            # Simple 3-column layout that works on all screen sizes
+            btn_prev, counter, btn_next = st.columns([1, 2, 1])
+
+            with btn_prev:
+                if st.button("◀", key=f"prev_{category_key}", use_container_width=True):
+                    st.session_state[idx_key] = last if idx == 0 else idx - 1
+                    st.session_state.deployment_selected_config = None
+                    st.session_state.deployment_selected_category = None
+                    st.session_state.deployment_yaml_generated = False
+                    st.session_state.deployment_yaml_files = {}
+                    st.session_state.deployment_id = None
+                    st.session_state.deployment_error = None
+                    st.session_state.deployed_to_cluster = False
+                    st.rerun()
+
+            with counter:
+                st.markdown(
+                    f"<div style='text-align: center; line-height: 2.4; font-size: 0.85rem;'>#{idx + 1} of {len(recs_list)}</div>",
+                    unsafe_allow_html=True,
+                )
+
+            with btn_next:
+                if st.button("▶", key=f"next_{category_key}", use_container_width=True):
+                    st.session_state[idx_key] = 0 if idx == last else idx + 1
+                    st.session_state.deployment_selected_config = None
+                    st.session_state.deployment_selected_category = None
+                    st.session_state.deployment_yaml_generated = False
+                    st.session_state.deployment_yaml_files = {}
+                    st.session_state.deployment_id = None
+                    st.session_state.deployment_error = None
+                    st.session_state.deployed_to_cluster = False
+                    st.rerun()
 
         selected_category = st.session_state.get("deployment_selected_category")
         is_selected = selected_category == category_key

--- a/ui/components/recommendations.py
+++ b/ui/components/recommendations.py
@@ -132,31 +132,48 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
             unsafe_allow_html=True,
         )
 
-        # Prev/Next navigation (circular) - compact horizontal layout for all screen sizes
+        # Prev/Next navigation (circular) - force horizontal layout on all screen sizes
         if len(recs_list) > 1:
             last = len(recs_list) - 1
 
-            # CSS to prevent columns from stacking on mobile
+            # Unique class for scoping CSS to just this navigation section
+            nav_class = f"nav-row-{category_key}"
+
+            # Maximum specificity CSS with media query override
             st.markdown(
-                """
+                f"""
                 <style>
-                /* Prevent column stacking on mobile for navigation */
-                @media (max-width: 768px) {
-                    [data-testid="stHorizontalBlock"] {
+                /* Ultra-high specificity to override Streamlit mobile styles */
+                div.{nav_class} [data-testid="stHorizontalBlock"] {{
+                    display: flex !important;
+                    flex-direction: row !important;
+                    flex-wrap: nowrap !important;
+                    gap: 0.5rem !important;
+                }}
+                div.{nav_class} [data-testid="column"] {{
+                    flex: 1 1 0 !important;
+                    min-width: 50px !important;
+                }}
+                /* Explicitly override mobile breakpoint */
+                @media only screen and (max-width: 640px) {{
+                    div.{nav_class} [data-testid="stHorizontalBlock"] {{
+                        display: flex !important;
+                        flex-direction: row !important;
                         flex-wrap: nowrap !important;
-                    }
-                    [data-testid="column"] {
-                        min-width: 0 !important;
-                        flex-shrink: 1 !important;
-                    }
-                }
+                    }}
+                    div.{nav_class} [data-testid="column"] {{
+                        width: auto !important;
+                        min-width: 50px !important;
+                    }}
+                }}
                 </style>
+                <div class="{nav_class}">
                 """,
                 unsafe_allow_html=True,
             )
 
-            # Compact button row
-            col1, col2, col3 = st.columns([0.8, 1.4, 0.8])
+            # Simple 3-column layout
+            col1, col2, col3 = st.columns([1, 1.5, 1])
 
             with col1:
                 if st.button("◀", key=f"prev_{category_key}", use_container_width=True):
@@ -187,6 +204,9 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
                     st.session_state.deployment_error = None
                     st.session_state.deployed_to_cluster = False
                     st.rerun()
+
+            # Close navigation wrapper div
+            st.markdown("</div>", unsafe_allow_html=True)
 
         selected_category = st.session_state.get("deployment_selected_category")
         is_selected = selected_category == category_key

--- a/ui/components/recommendations.py
+++ b/ui/components/recommendations.py
@@ -27,8 +27,7 @@ def _render_filter_summary():
     filter_pct = passed_configs / total_configs * 100
     st.markdown(
         f"""
-    <div style="display: flex; align-items: center; gap: 1.5rem; margin-bottom: 1rem; padding: 0.6rem 1rem;
-                border-radius: 8px; ">
+    <div style="display: flex; align-items: center; gap: 1.5rem; margin-bottom: 1rem;">
         <span style="font-size: 0.85rem;">
             <strong style="color: #10B981;">{passed_configs:,}</strong> configs passed SLO filter
             from <strong>{total_configs:,}</strong> total
@@ -124,7 +123,7 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
 
     with col, st.container(border=True):
         st.markdown(
-            f'<div style="line-height: 1.7;">'
+            f'<div style="line-height: 1.7; margin-bottom: 1rem;">'
             f'<strong style="font-size: 1.05rem;">{title}</strong>{badge_html}<br>'
             f'<span style="font-size: 0.9rem;"><strong>Solution:</strong> Model: {model_name} | Hardware: {hw_count}x {hw_type} | Replicas: {replicas}</span><br>'
             f'<span style="font-size: 0.9rem;"><strong>Scores:</strong> {scores_line}</span><br>'
@@ -133,55 +132,74 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
             unsafe_allow_html=True,
         )
 
-        # Prev/Next navigation (circular)
+        # Prev/Next navigation (circular) - compact centered layout
         if len(recs_list) > 1:
             last = len(recs_list) - 1
-            nav_prev, nav_label, nav_next = st.columns([1, 2, 1])
-            with nav_prev:
-                if st.button("<", key=f"prev_{category_key}"):
-                    st.session_state[idx_key] = last if idx == 0 else idx - 1
-                    st.session_state.deployment_selected_config = None
-                    st.session_state.deployment_selected_category = None
-                    st.session_state.deployment_yaml_generated = False
-                    st.session_state.deployment_yaml_files = {}
-                    st.session_state.deployment_id = None
-                    st.session_state.deployment_error = None
-                    st.session_state.deployed_to_cluster = False
-                    st.rerun()
-            with nav_label:
-                st.markdown(
-                    f"<div style='text-align: center; line-height: 2.4; font-size: 0.85rem;'>#{idx + 1} of {len(recs_list)}</div>",
-                    unsafe_allow_html=True,
-                )
-            with nav_next:
-                if st.button("\\>", key=f"next_{category_key}"):
-                    st.session_state[idx_key] = 0 if idx == last else idx + 1
-                    st.session_state.deployment_selected_config = None
-                    st.session_state.deployment_selected_category = None
-                    st.session_state.deployment_yaml_generated = False
-                    st.session_state.deployment_yaml_files = {}
-                    st.session_state.deployment_id = None
-                    st.session_state.deployment_error = None
-                    st.session_state.deployed_to_cluster = False
-                    st.rerun()
+
+            # Use narrow columns for compact centered navigation
+            spacer_l, nav_area, spacer_r = st.columns([0.3, 0.4, 0.3])
+            with nav_area:
+                btn_prev, counter, btn_next = st.columns([1, 1.5, 1])
+                with btn_prev:
+                    # Right-align the prev button using nested columns
+                    empty, btn = st.columns([0.3, 0.7])
+                    with btn:
+                        if st.button("◀", key=f"prev_{category_key}"):
+                            st.session_state[idx_key] = last if idx == 0 else idx - 1
+                            st.session_state.deployment_selected_config = None
+                            st.session_state.deployment_selected_category = None
+                            st.session_state.deployment_yaml_generated = False
+                            st.session_state.deployment_yaml_files = {}
+                            st.session_state.deployment_id = None
+                            st.session_state.deployment_error = None
+                            st.session_state.deployed_to_cluster = False
+                            st.rerun()
+                with counter:
+                    st.markdown(
+                        f"<div style='text-align: center; line-height: 2.4; font-size: 0.85rem;'>#{idx + 1} of {len(recs_list)}</div>",
+                        unsafe_allow_html=True,
+                    )
+                with btn_next:
+                    # Left-align but add spacing with nested columns
+                    btn, empty = st.columns([0.7, 0.3])
+                    with btn:
+                        if st.button("▶", key=f"next_{category_key}"):
+                            st.session_state[idx_key] = 0 if idx == last else idx + 1
+                            st.session_state.deployment_selected_config = None
+                            st.session_state.deployment_selected_category = None
+                            st.session_state.deployment_yaml_generated = False
+                            st.session_state.deployment_yaml_files = {}
+                            st.session_state.deployment_id = None
+                            st.session_state.deployment_error = None
+                            st.session_state.deployed_to_cluster = False
+                            st.rerun()
 
         selected_category = st.session_state.get("deployment_selected_category")
         is_selected = selected_category == category_key
 
         if is_selected:
-            if st.button(
-                "Selected", key=f"selected_{category_key}", width="stretch", type="primary"
-            ):
-                st.session_state.deployment_selected_config = None
-                st.session_state.deployment_selected_category = None
-                st.session_state.deployment_yaml_generated = False
-                st.session_state.deployment_yaml_files = {}
-                st.session_state.deployment_id = None
-                st.session_state.deployment_error = None
-                st.session_state.deployed_to_cluster = False
-                st.rerun()
+            # Show custom green "Selected" indicator (visual only)
+            st.markdown(
+                """
+                <div style="
+                    width: 100%;
+                    padding: 0.5rem 1rem;
+                    background-color: #D1FAE5;
+                    color: #065F46;
+                    border: 1px solid #10B981;
+                    border-radius: 0.375rem;
+                    font-size: 1rem;
+                    font-weight: 400;
+                    text-align: center;
+                    margin-bottom: 0.5rem;
+                ">
+                    ✓ Selected
+                </div>
+                """,
+                unsafe_allow_html=True,
+            )
         else:
-            if st.button("Select", key=f"select_{category_key}", width="stretch"):
+            if st.button("Select", key=f"select_{category_key}", use_container_width=True):
                 st.session_state.deployment_selected_config = rec
                 st.session_state.deployment_selected_category = category_key
                 st.session_state.deployment_yaml_generated = False
@@ -476,8 +494,6 @@ def render_recommendation_result(result: dict, priority: str, extraction: dict):
             for warn in estimation_warnings:
                 st.warning(warn)
 
-    st.markdown("---")
-
     # Get all recommendations for the cards
     all_recs: list[dict[str, Any]] = []
     for cat in ["balanced", "best_accuracy", "lowest_cost", "lowest_latency", "simplest"]:
@@ -503,15 +519,33 @@ def render_recommendation_result(result: dict, priority: str, extraction: dict):
     if unique_recs:
         render_top5_table(unique_recs, priority)
 
-    # === LIST OPTIONS SECTION (inline expandable) ===
+    # === VIEW DEPLOYMENT CONFIGURATION BUTTON ===
     st.markdown("<div style='height: 1.5rem;'></div>", unsafe_allow_html=True)
-    col_left, col_center, col_right = st.columns([1, 2, 1])
-    with col_center:
-        is_expanded = st.session_state.get("show_options_list_expanded", False)
-        button_text = "Hide Option List" if is_expanded else "List Options"
-        if st.button(button_text, key="list_options_btn", width="stretch"):
-            st.session_state.show_options_list_expanded = not is_expanded
-            st.rerun()
 
-    if st.session_state.get("show_options_list_expanded", False):
+    has_selection = st.session_state.get("deployment_selected_category") is not None
+
+    # Use columns to center and limit button width to ~500px
+    col_left, col_center, col_right = st.columns([1, 1, 1])
+    with col_center:
+        if has_selection:
+            if st.button(
+                "View Deployment Configuration",
+                key="view_deployment_config_btn",
+                use_container_width=True,
+                type="primary"
+            ):
+                # Navigate to Deployment tab (index 3)
+                st.session_state["_pending_tab"] = 3
+                st.rerun()
+        else:
+            st.button(
+                "View Deployment Configuration",
+                key="view_deployment_config_btn_disabled",
+                use_container_width=True,
+                disabled=True
+            )
+
+    # === CONFIGURATION OPTIONS SECTION ===
+    st.markdown("<div style='height: 1.5rem;'></div>", unsafe_allow_html=True)
+    with st.expander("Configuration Options", expanded=False):
         render_options_list_inline()

--- a/ui/components/recommendations.py
+++ b/ui/components/recommendations.py
@@ -132,14 +132,33 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
             unsafe_allow_html=True,
         )
 
-        # Prev/Next navigation (circular) - simplified responsive layout
+        # Prev/Next navigation (circular) - compact horizontal layout for all screen sizes
         if len(recs_list) > 1:
             last = len(recs_list) - 1
 
-            # Simple 3-column layout that works on all screen sizes
-            btn_prev, counter, btn_next = st.columns([1, 2, 1])
+            # CSS to prevent columns from stacking on mobile
+            st.markdown(
+                """
+                <style>
+                /* Prevent column stacking on mobile for navigation */
+                @media (max-width: 768px) {
+                    [data-testid="stHorizontalBlock"] {
+                        flex-wrap: nowrap !important;
+                    }
+                    [data-testid="column"] {
+                        min-width: 0 !important;
+                        flex-shrink: 1 !important;
+                    }
+                }
+                </style>
+                """,
+                unsafe_allow_html=True,
+            )
 
-            with btn_prev:
+            # Compact button row
+            col1, col2, col3 = st.columns([0.8, 1.4, 0.8])
+
+            with col1:
                 if st.button("◀", key=f"prev_{category_key}", use_container_width=True):
                     st.session_state[idx_key] = last if idx == 0 else idx - 1
                     st.session_state.deployment_selected_config = None
@@ -151,13 +170,13 @@ def _render_category_card(title, recs_list, highlight_field, category_key, col):
                     st.session_state.deployed_to_cluster = False
                     st.rerun()
 
-            with counter:
+            with col2:
                 st.markdown(
-                    f"<div style='text-align: center; line-height: 2.4; font-size: 0.85rem;'>#{idx + 1} of {len(recs_list)}</div>",
+                    f"<div style='text-align: center; line-height: 2.4; font-size: 0.85rem; white-space: nowrap;'>#{idx + 1} of {len(recs_list)}</div>",
                     unsafe_allow_html=True,
                 )
 
-            with btn_next:
+            with col3:
                 if st.button("▶", key=f"next_{category_key}", use_container_width=True):
                     st.session_state[idx_key] = 0 if idx == last else idx + 1
                     st.session_state.deployment_selected_config = None


### PR DESCRIPTION
## Description
This is a cleanup of the 'Recommendations' tab based on some of the recommendations in [issue #119](https://github.com/llm-d-incubation/llm-d-planner/issues/119).   This PR doesn't include all the changes in the proposal.

Recommendations tab improvements:
- Remove extraneous horizontal rule between tabs and content
- Replace List Options toggle button with Configuration Options accordion
- Redesign Selected button with green background and checkmark
- Add View Deployment Configuration button (disabled until selection)
- Redesign back/forward controls for paging through models in the recommendation cards
- Remove padding from filter summary under the header for tighter spacing

Deployment tab improvements:
- Remove padding from Model/GPU/Replicas info for consistency

Global improvements:
- Reduce logo-to-heading spacing in header
- Fix column gap issues across all tabs by adding explicit gap parameters

Assisted-by: Claude 

BEFORE

<img width="1880" height="1266" alt="image" src="https://github.com/user-attachments/assets/03d44fb1-7ddb-4cc1-a14f-b3ce01344a47" />

AFTER

<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/2f8469f1-35fc-4fe1-a4fb-edf4912c7594" />

<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/9c47b731-77b8-4139-b5cd-338eb8e1504c" />


## How Has This Been Tested?
This can be tested by running the project locally in demo mode, and going through the primary flow.
Analyze use case -> Generate specification -> generate recommendations.
From there click through and select a model, open the accordion to see the 'configuration options', and click 'View Deployment Configuration' to see your choice reflected in the 'Deployment' tab.

All these changes are on the front end in the streamlit-generated views and should not impact any other area of the code.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
