### PR TITLE
refactor: remove load_206_models() and all associated dead code

### DIFF
--- a/src/planner/api/routes/reference_data.py
+++ b/src/planner/api/routes/reference_data.py
@@ -57,40 +57,6 @@ async def list_use_cases(slo_repo: SLOTemplateRepository = Depends(get_slo_repo)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)) from e
 
 
-@router.get("/benchmarks")
-async def get_benchmarks():
-    """Get all 206 models benchmark data from opensource_all_benchmarks.csv."""
-    try:
-        csv_path = _get_data_path() / "benchmarks" / "accuracy" / "opensource_all_benchmarks.csv"
-
-        if not csv_path.exists():
-            logger.error(f"Benchmark CSV not found at: {csv_path}")
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Benchmark data file not found"
-            )
-
-        # Read CSV using built-in csv module
-        records = []
-        with open(csv_path, encoding="utf-8") as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                # Filter out rows with empty/missing Model Name
-                if row.get("Model Name") and row["Model Name"].strip():
-                    records.append(row)
-
-        logger.info(f"Loaded {len(records)} benchmark records from CSV")
-
-        return {"success": True, "count": len(records), "benchmarks": records}
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to load benchmarks: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to load benchmarks: {str(e)}",
-        ) from e
-
-
 @router.get("/priority-weights")
 async def get_priority_weights():
     """Get priority to weight mapping configuration.

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -8,7 +8,6 @@ import logging
 import os
 from typing import Any, cast
 
-import pandas as pd
 import requests
 import streamlit as st
 
@@ -21,31 +20,6 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
-
-
-@st.cache_data
-def load_206_models() -> pd.DataFrame:
-    """Load all 206 models from backend API."""
-    try:
-        response = requests.get(
-            f"{API_BASE_URL}/api/v1/benchmarks",
-            timeout=DEFAULT_TIMEOUT,
-        )
-        response.raise_for_status()
-        data = response.json()
-
-        if data.get("success") and data.get("benchmarks"):
-            df = pd.DataFrame(data["benchmarks"])
-            if "Model Name" in df.columns:
-                df = df.dropna(subset=["Model Name"])
-                df = df[df["Model Name"].str.strip() != ""]
-            return df
-        else:
-            logger.warning("No benchmark data returned from API")
-            return pd.DataFrame()
-    except Exception as e:
-        logger.error(f"Failed to load benchmarks from API: {e}")
-        return pd.DataFrame()
 
 
 @st.cache_data(ttl=300)

--- a/ui/app.py
+++ b/ui/app.py
@@ -15,13 +15,11 @@ from pathlib import Path
 # Add ui/ to sys.path so modules can use flat imports
 sys.path.insert(0, str(Path(__file__).parent))
 
-import pandas as pd
 import streamlit as st
 from api_client import (
     extract_business_context,
     fetch_priority_weights,
     fetch_ranked_recommendations,
-    load_206_models,
 )
 from components.deployment import render_deployment_tab
 from components.deployment_management import render_deployment_management_tab
@@ -121,7 +119,7 @@ def render_hero():
 # =============================================================================
 
 
-def render_use_case_input_tab(priority: str, models_df: pd.DataFrame):
+def render_use_case_input_tab(priority: str):
     """Tab 1: Use case input interface."""
 
     def clear_dialog_states():
@@ -368,12 +366,12 @@ def render_use_case_input_tab(priority: str, models_df: pd.DataFrame):
 
     # Show extraction with approval if extraction exists but not approved
     if st.session_state.extraction_result and st.session_state.extraction_approved is None:
-        render_extraction_with_approval(st.session_state.extraction_result, models_df)
+        render_extraction_with_approval(st.session_state.extraction_result)
         return
 
     # If editing, show edit form
     if st.session_state.extraction_approved is False:
-        render_extraction_edit_form(st.session_state.extraction_result, models_df)
+        render_extraction_edit_form(st.session_state.extraction_result)
         return
 
     # If approved, show message to proceed to Technical Specifications tab
@@ -425,7 +423,7 @@ def render_technical_specs_tab():
         )
 
 
-def render_results_tab(priority: str, models_df: pd.DataFrame):
+def render_results_tab(priority: str):
     """Tab 3: Results display - Best Model Recommendations."""
     used_priority = st.session_state.get("used_priority", priority)
 
@@ -509,7 +507,7 @@ def render_results_tab(priority: str, models_df: pd.DataFrame):
         st.session_state.recommendation_result is None
         or st.session_state.get("_last_spec_fingerprint") != spec_fingerprint
     ):
-        with st.spinner(f"Scoring {len(models_df)} models with MCDM..."):
+        with st.spinner("Scoring models with MCDM..."):
             recommendation = fetch_ranked_recommendations(
                 use_case=use_case,
                 user_count=user_count,
@@ -553,11 +551,6 @@ def main():
     elif st.session_state.show_full_table_dialog:
         show_full_table_dialog()
 
-    # Load models
-    if st.session_state.models_df is None:
-        st.session_state.models_df = load_206_models()
-    models_df = st.session_state.models_df
-
     priority = "balanced"
 
     # Main Content - Compact hero
@@ -576,13 +569,13 @@ def main():
     )
 
     with tab1:
-        render_use_case_input_tab(priority, models_df)
+        render_use_case_input_tab(priority)
 
     with tab2:
         render_technical_specs_tab()
 
     with tab3:
-        render_results_tab(priority, models_df)
+        render_results_tab(priority)
 
     with tab4:
         render_deployment_tab()

--- a/ui/components/extraction.py
+++ b/ui/components/extraction.py
@@ -58,7 +58,7 @@ def render_extraction_result(extraction: dict, priority: str):
         st.rerun()
 
 
-def render_extraction_with_approval(extraction: dict, models_df):
+def render_extraction_with_approval(extraction: dict):
     """Render extraction results with YES/NO approval buttons."""
     st.subheader("Extracted Business Context")
 
@@ -111,7 +111,7 @@ def render_extraction_with_approval(extraction: dict, models_df):
             st.rerun()
 
 
-def render_extraction_edit_form(extraction: dict, models_df):
+def render_extraction_edit_form(extraction: dict):
     """Render editable form for extraction correction."""
     st.subheader("Edit Business Context")
     st.info('Review and adjust the extracted values below, then click "Apply Changes" to continue.')

--- a/ui/state.py
+++ b/ui/state.py
@@ -9,7 +9,6 @@ SESSION_DEFAULTS: dict[str, Any] = {
     "extraction_result": None,
     "recommendation_result": None,
     "user_input": "",
-    "models_df": None,
     "selected_model": None,
     # Workflow approval (None = pending, True = approved, False = editing)
     "extraction_approved": None,


### PR DESCRIPTION
## Description
The function loaded benchmark CSV data via /api/v1/benchmarks and threaded the resulting DataFrame through 5 function signatures, but it was
never consumed for any logic — only used in a spinner message. Remove the function, the unused models_df parameter plumbing, the now-orphaned API
 endpoint, and the pandas dependency in api_client.py.

## How Has This Been Tested?

- `make format` — no changes needed
- `make lint` — all checks passed
- `make typecheck` — no issues found in 116 source files
- `make test` — all passed
- Grep confirmed no remaining references to `load_206_models`, `models_df`, or `/api/v1/benchmarks` in `src/`, `ui/`, or `tests/`
- Manually tested Planner web UI.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work