### PR TITLE
refactor: rename container image targets to image-* prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,12 +249,27 @@ make db-load-estimated  # Load estimated performance data
 make db-shell           # Open psql shell
 ```
 
+### Container Images
+
+```bash
+make image-build-backend    # Build backend container image
+make image-build-ui         # Build UI container image
+make image-build-simulator  # Build vLLM simulator container image
+make image-build            # Build all container images
+make image-push             # Push all container images to Quay.io
+```
+
+Container runtime auto-detects Docker or Podman. Override with `CONTAINER_TOOL=podman make ...`.
+
 ### Docker Compose (alternative to native services)
 
 ```bash
 make docker-up          # Start all services via Docker Compose
-make docker-down        # Stop all
 make docker-up-dev      # Development mode with live reload
+make docker-down        # Stop all
+make docker-down-v      # Stop and remove volumes
+make docker-logs        # Follow logs from all services
+make docker-ps          # Show status of services
 ```
 
 ### Kubernetes / KIND Cluster
@@ -265,15 +280,6 @@ make cluster-stop       # Delete cluster
 make cluster-status     # Show status
 make clean-deployments  # Delete all InferenceServices
 ```
-
-### Container Builds
-
-```bash
-make build-backend      # Build backend Docker image
-make build-simulator    # Build vLLM simulator image
-```
-
-Container runtime auto-detects Docker or Podman. Override with `CONTAINER_TOOL=podman make ...`.
 
 ## Working with This Repository
 

--- a/Makefile
+++ b/Makefile
@@ -282,16 +282,32 @@ open-ui: ## Open UI in browser
 open-backend: ## Open backend API docs in browser
 	@$(OPEN_CMD) http://localhost:8000/docs
 
-##@ Docker & Simulator
+##@ Container Images
 
-build-backend: ## Build backend Docker image
+image-build-backend: ## Build backend container image
 	@printf "$(BLUE)Building backend image...$(NC)\n"
 	$(CONTAINER_TOOL) build -f Dockerfile -t $(BACKEND_IMAGE):$(BACKEND_TAG) -t $(BACKEND_FULL_IMAGE) .
 	@printf "$(GREEN)✓ Backend image built:$(NC)\n"
 	@printf "  - $(BACKEND_IMAGE):$(BACKEND_TAG)\n"
 	@printf "  - $(BACKEND_FULL_IMAGE)\n"
 
-push-backend: build-backend ## Push backend image to Quay.io
+image-build-ui: ## Build UI container image
+	@printf "$(BLUE)Building UI image...$(NC)\n"
+	$(CONTAINER_TOOL) build -f ui/Dockerfile -t $(UI_IMAGE):$(UI_TAG) -t $(UI_FULL_IMAGE) .
+	@printf "$(GREEN)✓ UI image built:$(NC)\n"
+	@printf "  - $(UI_IMAGE):$(UI_TAG)\n"
+	@printf "  - $(UI_FULL_IMAGE)\n"
+
+image-build-simulator: ## Build vLLM simulator container image
+	@printf "$(BLUE)Building simulator image...$(NC)\n"
+	$(CONTAINER_TOOL) build -f $(SIMULATOR_DIR)/Dockerfile -t vllm-simulator:latest -t $(SIMULATOR_FULL_IMAGE) .
+	@printf "$(GREEN)✓ Simulator image built:$(NC)\n"
+	@printf "  - vllm-simulator:latest\n"
+	@printf "  - $(SIMULATOR_FULL_IMAGE)\n"
+
+image-build: image-build-backend image-build-ui image-build-simulator ## Build all container images
+
+image-push-backend: image-build-backend ## Push backend image to Quay.io
 	@printf "$(BLUE)Pushing backend image to $(BACKEND_FULL_IMAGE)...$(NC)\n"
 	@if ! $(CONTAINER_TOOL) login quay.io --get-login > /dev/null 2>&1; then \
 		printf "$(YELLOW)Not logged in to Quay.io. Please login:$(NC)\n"; \
@@ -303,16 +319,20 @@ push-backend: build-backend ## Push backend image to Quay.io
 	$(CONTAINER_TOOL) push $(BACKEND_FULL_IMAGE)
 	@printf "$(GREEN)✓ Image pushed to $(BACKEND_FULL_IMAGE)$(NC)\n"
 
-build-simulator: ## Build vLLM simulator Docker image
-	@printf "$(BLUE)Building simulator image...$(NC)\n"
-	$(CONTAINER_TOOL) build -f $(SIMULATOR_DIR)/Dockerfile -t vllm-simulator:latest -t $(SIMULATOR_FULL_IMAGE) .
-	@printf "$(GREEN)✓ Simulator image built:$(NC)\n"
-	@printf "  - vllm-simulator:latest\n"
-	@printf "  - $(SIMULATOR_FULL_IMAGE)\n"
+image-push-ui: image-build-ui ## Push UI image to Quay.io
+	@printf "$(BLUE)Pushing UI image to $(UI_FULL_IMAGE)...$(NC)\n"
+	@if ! $(CONTAINER_TOOL) login quay.io --get-login > /dev/null 2>&1; then \
+		printf "$(YELLOW)Not logged in to Quay.io. Please login:$(NC)\n"; \
+		$(CONTAINER_TOOL) login quay.io || (printf "$(RED)✗ Login failed$(NC)\n" && exit 1); \
+	else \
+		printf "$(GREEN)✓ Already logged in to Quay.io$(NC)\n"; \
+	fi
+	@printf "$(BLUE)Pushing image...$(NC)\n"
+	$(CONTAINER_TOOL) push $(UI_FULL_IMAGE)
+	@printf "$(GREEN)✓ Image pushed to $(UI_FULL_IMAGE)$(NC)\n"
 
-push-simulator: build-simulator ## Push simulator image to Quay.io
+image-push-simulator: image-build-simulator ## Push simulator image to Quay.io
 	@printf "$(BLUE)Pushing simulator image to $(SIMULATOR_FULL_IMAGE)...$(NC)\n"
-	@# Check if logged in to Quay.io
 	@if ! $(CONTAINER_TOOL) login quay.io --get-login > /dev/null 2>&1; then \
 		printf "$(YELLOW)Not logged in to Quay.io. Please login:$(NC)\n"; \
 		$(CONTAINER_TOOL) login quay.io || (printf "$(RED)✗ Login failed$(NC)\n" && exit 1); \
@@ -323,24 +343,9 @@ push-simulator: build-simulator ## Push simulator image to Quay.io
 	$(CONTAINER_TOOL) push $(SIMULATOR_FULL_IMAGE)
 	@printf "$(GREEN)✓ Image pushed to $(SIMULATOR_FULL_IMAGE)$(NC)\n"
 
-pull-simulator: ## Pull simulator image from Quay.io
-	@printf "$(BLUE)Pulling simulator image from $(SIMULATOR_FULL_IMAGE)...$(NC)\n"
-	$(CONTAINER_TOOL) pull $(SIMULATOR_FULL_IMAGE)
-	$(CONTAINER_TOOL) tag $(SIMULATOR_FULL_IMAGE) vllm-simulator:latest
-	@printf "$(GREEN)✓ Image pulled and tagged as vllm-simulator:latest$(NC)\n"
+image-push: image-push-backend image-push-ui image-push-simulator ## Push all container images to Quay.io
 
-docker-build: ## Build all Docker images
-	@printf "$(BLUE)Building all Docker images...$(NC)\n"
-	DOCKER_BUILDKIT=1 docker-compose build --parallel
-	@printf "$(GREEN)✓ All images built$(NC)\n"
-
-docker-push: ## Push backend and UI images to $(REGISTRY)/$(REGISTRY_ORG)
-	@printf "$(BLUE)Tagging and pushing images to $(REGISTRY)/$(REGISTRY_ORG)...$(NC)\n"
-	$(CONTAINER_TOOL) tag $(BACKEND_IMAGE):$(BACKEND_TAG) $(BACKEND_FULL_IMAGE)
-	$(CONTAINER_TOOL) tag $(UI_IMAGE):$(UI_TAG) $(UI_FULL_IMAGE)
-	$(CONTAINER_TOOL) push $(BACKEND_FULL_IMAGE)
-	$(CONTAINER_TOOL) push $(UI_FULL_IMAGE)
-	@printf "$(GREEN)✓ Images pushed to $(REGISTRY)/$(REGISTRY_ORG)$(NC)\n"
+##@ Docker Compose
 
 docker-up: ## Start all services with Docker Compose
 	@printf "$(BLUE)Starting all services with Docker Compose...$(NC)\n"
@@ -376,40 +381,15 @@ docker-down-v: ## Stop and remove volumes
 	docker-compose down -v
 	@printf "$(GREEN)✓ Services stopped and volumes removed$(NC)\n"
 
-docker-logs: ## View logs from all Docker services
+docker-logs: ## View logs from all Docker Compose services
 	@docker-compose logs -f
-
-docker-logs-backend: ## View backend Docker logs
-	@docker-compose logs -f backend
-
-docker-logs-ui: ## View UI Docker logs
-	@docker-compose logs -f ui
 
 docker-ps: ## Show status of Docker Compose services
 	@docker-compose ps
 
-docker-restart: ## Restart Docker Compose services
-	@printf "$(BLUE)Restarting Docker Compose services...$(NC)\n"
-	docker-compose restart
-	@printf "$(GREEN)✓ Services restarted$(NC)\n"
-
-docker-clean: ## Remove all Docker resources
-	@printf "$(BLUE)Cleaning Docker resources...$(NC)\n"
-	docker-compose down -v --remove-orphans
-	@printf "$(GREEN)✓ Docker resources cleaned$(NC)\n"
-
-docker-shell-backend: ## Open shell in backend container
-	@docker-compose exec backend /bin/bash
-
-docker-shell-ui: ## Open shell in UI container
-	@docker-compose exec ui /bin/bash
-
-docker-shell-postgres: ## Open PostgreSQL shell in container
-	@docker-compose exec postgres psql -U planner -d planner
-
 ##@ Kubernetes Cluster
 
-cluster-start: check-prereqs build-simulator ## Create KIND cluster and load simulator image
+cluster-start: check-prereqs image-build-simulator ## Create KIND cluster and load simulator image
 	@printf "$(BLUE)Creating KIND cluster...$(NC)\n"
 	./scripts/kind-cluster.sh start
 	@printf "$(GREEN)✓ Cluster ready!$(NC)\n"
@@ -427,7 +407,7 @@ cluster-restart: ## Restart KIND cluster
 cluster-status: ## Show cluster status
 	./scripts/kind-cluster.sh status
 
-cluster-load-simulator: build-simulator ## Load simulator image into KIND cluster
+cluster-load-simulator: image-build-simulator ## Load simulator image into KIND cluster
 	@printf "$(BLUE)Loading simulator image into KIND cluster...$(NC)\n"
 	kind load docker-image vllm-simulator:latest --name $(KIND_CLUSTER_NAME)
 	@printf "$(GREEN)✓ Simulator image loaded$(NC)\n"

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -637,7 +637,7 @@ make format
 ### Building the Simulator
 
 ```bash
-make build-simulator
+make image-build-simulator
 ```
 
 Creates `vllm-simulator:latest` Docker image.
@@ -661,7 +661,7 @@ curl -X POST http://localhost:8080/v1/completions \
 ### Pushing to Quay.io
 
 ```bash
-make push-simulator
+make image-push-simulator
 ```
 
 Auto-prompts for login if not authenticated.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -57,20 +57,13 @@ This repository includes a **Makefile** that provides convenient shortcuts for a
 
 | Task | Docker Compose Command | Makefile Shortcut |
 |------|------------------------|-------------------|
-| **Build images** | `docker-compose build` | `make docker-build` |
+| **Build images** | `docker-compose build` | `make image-build` |
 | **Start services** | `docker-compose up -d` | `make docker-up` |
 | **Start dev mode** | `docker-compose -f docker-compose.yml -f docker-compose.dev.yml up` | `make docker-up-dev` |
 | **Stop services** | `docker-compose down` | `make docker-down` |
 | **Stop + remove volumes** | `docker-compose down -v` | `make docker-down-v` |
-| **View logs (all)** | `docker-compose logs -f` | `make docker-logs` |
-| **View backend logs** | `docker-compose logs -f backend` | `make docker-logs-backend` |
-| **View UI logs** | `docker-compose logs -f ui` | `make docker-logs-ui` |
+| **View logs** | `docker-compose logs -f` | `make docker-logs` |
 | **Check status** | `docker-compose ps` | `make docker-ps` |
-| **Restart services** | `docker-compose restart` | `make docker-restart` |
-| **Clean everything** | `docker-compose down -v --remove-orphans` | `make docker-clean` |
-| **Backend shell** | `docker-compose exec backend /bin/bash` | `make docker-shell-backend` |
-| **UI shell** | `docker-compose exec ui /bin/bash` | `make docker-shell-ui` |
-| **PostgreSQL shell** | `docker-compose exec postgres psql -U planner -d planner` | `make docker-shell-postgres` |
 
 ### Examples
 
@@ -84,9 +77,9 @@ docker-compose down
 
 **Using Makefile (equivalent):**
 ```bash
-make docker-build
+make image-build
 make docker-up
-make docker-logs-backend
+make docker-logs
 make docker-down
 ```
 
@@ -127,7 +120,12 @@ All operations below show both `docker-compose` commands and their `make` equiva
 ```bash
 # Build all images
 docker-compose build
-make docker-build
+make image-build
+
+# Build specific images
+make image-build-backend
+make image-build-ui
+make image-build-simulator
 
 # Build specific service (docker-compose only)
 docker-compose build backend
@@ -153,22 +151,17 @@ make docker-down-v
 
 # Restart services
 docker-compose restart
-make docker-restart
 
-# Restart specific service (docker-compose only)
+# Restart specific service
 docker-compose restart backend
 
 # View logs (all services)
 docker-compose logs -f
 make docker-logs
 
-# View backend logs
+# View specific service logs
 docker-compose logs -f backend
-make docker-logs-backend
-
-# View UI logs
 docker-compose logs -f ui
-make docker-logs-ui
 
 # Check service status
 docker-compose ps
@@ -180,7 +173,6 @@ make docker-ps
 ```bash
 # Access PostgreSQL CLI
 docker-compose exec postgres psql -U planner -d planner
-make docker-shell-postgres
 
 # Run database migrations/scripts
 docker-compose exec postgres psql -U planner -d planner -f /scripts/schema.sql
@@ -285,10 +277,7 @@ make docker-logs
 
 # View specific service logs
 docker-compose logs -f backend
-make docker-logs-backend
-
 docker-compose logs -f ui
-make docker-logs-ui
 ```
 
 #### Access Container Shell
@@ -296,15 +285,12 @@ make docker-logs-ui
 ```bash
 # Backend container
 docker-compose exec backend /bin/bash
-make docker-shell-backend
 
 # UI container
 docker-compose exec ui /bin/bash
-make docker-shell-ui
 
 # PostgreSQL container
 docker-compose exec postgres /bin/bash
-make docker-shell-postgres
 ```
 
 #### Check Service Health
@@ -371,9 +357,7 @@ docker system prune  # Free up space
 **Check service logs:**
 ```bash
 docker-compose logs backend
-make docker-logs-backend
-
-docker-compose logs postgres  # Use docker-compose for PostgreSQL
+docker-compose logs postgres
 ```
 
 **Verify dependencies:**
@@ -390,7 +374,7 @@ docker-compose exec postgres psql -U planner -c "\dt"
 **Ensure PostgreSQL is healthy:**
 ```bash
 docker-compose ps postgres
-make docker-ps  # Show all services
+make docker-ps
 
 docker-compose logs postgres
 ```


### PR DESCRIPTION
The container image-related `make` commands were inconsistent, and contained `docker` in the name even though we can use either `docker` or `podman`.  This pr changes the prefix to `image`, makes them more consistent, and removes some unnecessary shortcuts.

- Rename build/push Makefile targets to use a tool-agnostic image-* prefix (e.g. image-build-backend, image-push-simulator). 
- Add missing image-build-ui / image-push-ui targets. 
- Replace docker-build/docker-push with image-build/image-push. 
- Remove thin compose wrappers (docker-restart, docker-clean, docker-shell-*, docker-logs-backend, docker-logs-ui) that duplicate one-liner docker-compose commands. 
- Drop pull-simulator target.

New Commands:
```bash
Container Images
  image-build-backend    Build backend container image
  image-build-ui         Build UI container image
  image-build-simulator   Build vLLM simulator container image
  image-build            Build all container images
  image-push-backend     Push backend image to Quay.io
  image-push-ui          Push UI image to Quay.io
  image-push-simulator   Push simulator image to Quay.io
  image-push             Push all container images to Quay.io

Docker Compose
  docker-up              Start all services with Docker Compose
  docker-up-dev          Start all services with Docker Compose (development mode)
  docker-down            Stop all Docker Compose services
  docker-down-v          Stop and remove volumes
  docker-logs            View logs from all Docker Compose services
  docker-ps              Show status of Docker Compose services
```