### PR TITLE
fix: preserve full model name in catalog sync

### DIFF
--- a/src/planner/knowledge_base/model_catalog_sync.py
+++ b/src/planner/knowledge_base/model_catalog_sync.py
@@ -120,7 +120,7 @@ def _catalog_model_to_model_info(model: dict) -> ModelInfo:
     return _ModelInfo(
         {
             "model_id": name,
-            "name": name.split("/")[-1],
+            "name": name,
             "provider": model.get("provider", "Unknown"),
             "family": _extract_family(name),
             "size_parameters": _parse_size(size_str) if size_str else f"{param_b}B",


### PR DESCRIPTION
## Description

When syncing models from the RHOAI Model Catalog, `_catalog_model_to_model_info` was stripping
the provider prefix from model names (_e.g._, `"RedHatAI/gpt-oss-20b"` → `"gpt-oss-20b"`).

The `model.name` field flows into `DeploymentRecommendation.model_name` (via _config_finder.py_),
which downstream consumers (e.g., rhoai-mcp) use to look up models in the Model Catalog API.
The API stores the full prefixed name, so exact-match lookups against the shortened name fail.

The fix preserves the full catalog name in the `name` field, aligning it with `model_id`
(which was already the full name). `_extract_family()` already handles the prefix internally
via `name.split("/")[-1]`, so no other changes are needed.

## How Has This Been Tested?

All unit tests passed, specifically ran model catalog sync and merge tests:
`uv run pytest -q ./tests/unit/test_model_catalog_sync.py ./tests/unit/test_model_catalog_merge.py`

Additionally verified by tracing the issue end-to-end on an OpenShift deployment where
the planner backend syncs from a live Model Catalog instance.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
