### PR TITLE
feat: expose benchmark_source in /api/v1/db/status

### DIFF
--- a/src/planner/api/routes/database.py
+++ b/src/planner/api/routes/database.py
@@ -14,7 +14,6 @@ import os
 import psycopg2
 from fastapi import APIRouter, File, Header, HTTPException, UploadFile, status
 
-from planner.api.dependencies import _get_benchmark_source_type
 from planner.knowledge_base.loader import (
     extract_metadata,
     get_db_stats,
@@ -64,17 +63,6 @@ async def verify_admin(x_admin_password: str | None = Header(None)):
     return {"verified": True}
 
 
-def _build_benchmark_source_info() -> dict:
-    """Build the benchmark_source section for status responses."""
-    source_type = _get_benchmark_source_type()
-    info: dict = {"type": source_type}
-    if source_type == "model_catalog":
-        info["model_catalog_source_id"] = (
-            os.getenv("MODEL_CATALOG_SOURCE_ID", "").strip() or "redhat_ai_validated_models"
-        )
-    return info
-
-
 @router.get("/db/status")
 async def db_status():
     """Get current benchmark database statistics."""
@@ -85,7 +73,6 @@ async def db_status():
             return {
                 "success": True,
                 **stats,
-                "benchmark_source": _build_benchmark_source_info(),
             }
         finally:
             conn.close()

--- a/src/planner/api/routes/database.py
+++ b/src/planner/api/routes/database.py
@@ -14,6 +14,7 @@ import os
 import psycopg2
 from fastapi import APIRouter, File, Header, HTTPException, UploadFile, status
 
+from planner.api.dependencies import _get_benchmark_source_type
 from planner.knowledge_base.loader import (
     extract_metadata,
     get_db_stats,
@@ -63,6 +64,17 @@ async def verify_admin(x_admin_password: str | None = Header(None)):
     return {"verified": True}
 
 
+def _build_benchmark_source_info() -> dict:
+    """Build the benchmark_source section for status responses."""
+    source_type = _get_benchmark_source_type()
+    info: dict = {"type": source_type}
+    if source_type == "model_catalog":
+        info["model_catalog_source_id"] = (
+            os.getenv("MODEL_CATALOG_SOURCE_ID", "").strip() or "redhat_ai_validated_models"
+        )
+    return info
+
+
 @router.get("/db/status")
 async def db_status():
     """Get current benchmark database statistics."""
@@ -70,7 +82,11 @@ async def db_status():
         conn = _get_connection()
         try:
             stats = get_db_stats(conn)
-            return {"success": True, **stats}
+            return {
+                "success": True,
+                **stats,
+                "benchmark_source": _build_benchmark_source_info(),
+            }
         finally:
             conn.close()
     except Exception as e:

--- a/src/planner/knowledge_base/loader.py
+++ b/src/planner/knowledge_base/loader.py
@@ -289,6 +289,18 @@ def get_db_stats(conn) -> dict:
         for r in cursor.fetchall()
     ]
 
+    # Get benchmark source breakdown
+    cursor.execute("""
+        SELECT source, confidence_level, COUNT(*) as count
+        FROM exported_summaries
+        GROUP BY source, confidence_level
+        ORDER BY count DESC;
+    """)
+    stats["benchmark_sources"] = [
+        {"source": r["source"], "confidence_level": r["confidence_level"], "count": r["count"]}
+        for r in cursor.fetchall()
+    ]
+
     cursor.close()
     return stats
 

--- a/tests/test_postgresql_integration.py
+++ b/tests/test_postgresql_integration.py
@@ -15,6 +15,7 @@ Tests cover:
 import pytest
 
 from planner.knowledge_base.benchmarks import BenchmarkData, BenchmarkRepository
+from planner.knowledge_base.loader import get_db_stats
 from planner.knowledge_base.slo_templates import SLOTemplateRepository
 
 
@@ -31,6 +32,22 @@ class TestBenchmarkRepository:
         """Test that we can connect to PostgreSQL."""
         assert repo is not None
         assert repo.database_url is not None
+
+    def test_db_stats_include_benchmark_sources(self, repo):
+        """Test that get_db_stats returns benchmark_sources from real data."""
+        conn = repo._get_connection()
+        try:
+            stats = get_db_stats(conn)
+        finally:
+            conn.close()
+
+        sources = stats["benchmark_sources"]
+        assert len(sources) > 0
+        for entry in sources:
+            assert entry["source"]
+            assert entry["confidence_level"]
+            assert entry["count"] > 0
+        assert sum(e["count"] for e in sources) == stats["total_benchmarks"]
 
     def test_get_benchmark_exact_match(self, repo):
         """Test retrieving a benchmark with exact traffic profile match."""

--- a/tests/unit/test_database_routes.py
+++ b/tests/unit/test_database_routes.py
@@ -85,13 +85,29 @@ class TestDbStatus:
         with (
             patch("planner.api.routes.database._get_connection", return_value=mock_conn),
             patch("planner.api.routes.database.get_db_stats", return_value=stats),
+            patch("planner.api.routes.database._get_benchmark_source_type", return_value="postgresql"),
         ):
             resp = client.get("/api/v1/db/status")
         assert resp.status_code == 200
         body = resp.json()
         assert body["success"] is True
         assert body["total_benchmarks"] == 100
+        assert body["benchmark_source"] == {"type": "postgresql"}
         mock_conn.close.assert_called_once()
+
+    def test_includes_benchmark_source_model_catalog(self, client):
+        mock_conn = MagicMock()
+        stats = _sample_stats()
+        with (
+            patch("planner.api.routes.database._get_connection", return_value=mock_conn),
+            patch("planner.api.routes.database.get_db_stats", return_value=stats),
+            patch("planner.api.routes.database._get_benchmark_source_type", return_value="model_catalog"),
+            patch.dict("os.environ", {"MODEL_CATALOG_SOURCE_ID": "my_catalog"}),
+        ):
+            resp = client.get("/api/v1/db/status")
+        assert resp.status_code == 200
+        source = resp.json()["benchmark_source"]
+        assert source == {"type": "model_catalog", "model_catalog_source_id": "my_catalog"}
 
     def test_returns_503_on_db_error(self, client):
         with patch(

--- a/tests/unit/test_database_routes.py
+++ b/tests/unit/test_database_routes.py
@@ -19,14 +19,20 @@ def client():
     return TestClient(_app)
 
 
-def _sample_stats():
-    return {
+def _sample_stats(**overrides):
+    base = {
         "num_models": 3,
         "num_hardware_types": 2,
         "num_traffic_profiles": 4,
         "total_benchmarks": 100,
         "traffic_distribution": [],
+        "benchmark_sources": [
+            {"source": "blis", "confidence_level": "benchmarked", "count": 80},
+            {"source": "estimated", "confidence_level": "estimated", "count": 20},
+        ],
     }
+    base.update(overrides)
+    return base
 
 
 # --- GET /api/v1/db/admin-required ---
@@ -85,34 +91,44 @@ class TestDbStatus:
         with (
             patch("planner.api.routes.database._get_connection", return_value=mock_conn),
             patch("planner.api.routes.database.get_db_stats", return_value=stats),
-            patch(
-                "planner.api.routes.database._get_benchmark_source_type", return_value="postgresql"
-            ),
         ):
             resp = client.get("/api/v1/db/status")
         assert resp.status_code == 200
         body = resp.json()
         assert body["success"] is True
         assert body["total_benchmarks"] == 100
-        assert body["benchmark_source"] == {"type": "postgresql"}
+        assert body["benchmark_sources"] == [
+            {"source": "blis", "confidence_level": "benchmarked", "count": 80},
+            {"source": "estimated", "confidence_level": "estimated", "count": 20},
+        ]
         mock_conn.close.assert_called_once()
 
-    def test_includes_benchmark_source_model_catalog(self, client):
+    def test_benchmark_sources_empty_db(self, client):
         mock_conn = MagicMock()
-        stats = _sample_stats()
+        stats = _sample_stats(total_benchmarks=0, benchmark_sources=[])
         with (
             patch("planner.api.routes.database._get_connection", return_value=mock_conn),
             patch("planner.api.routes.database.get_db_stats", return_value=stats),
-            patch(
-                "planner.api.routes.database._get_benchmark_source_type",
-                return_value="model_catalog",
-            ),
-            patch.dict("os.environ", {"MODEL_CATALOG_SOURCE_ID": "my_catalog"}),
         ):
             resp = client.get("/api/v1/db/status")
         assert resp.status_code == 200
-        source = resp.json()["benchmark_source"]
-        assert source == {"type": "model_catalog", "model_catalog_source_id": "my_catalog"}
+        assert resp.json()["benchmark_sources"] == []
+
+    def test_benchmark_sources_multiple_origins(self, client):
+        mock_conn = MagicMock()
+        sources = [
+            {"source": "model_catalog", "confidence_level": "benchmarked", "count": 2800},
+            {"source": "guidellm", "confidence_level": "benchmarked", "count": 463},
+            {"source": "estimated", "confidence_level": "estimated", "count": 200},
+        ]
+        stats = _sample_stats(total_benchmarks=3463, benchmark_sources=sources)
+        with (
+            patch("planner.api.routes.database._get_connection", return_value=mock_conn),
+            patch("planner.api.routes.database.get_db_stats", return_value=stats),
+        ):
+            resp = client.get("/api/v1/db/status")
+        assert resp.status_code == 200
+        assert resp.json()["benchmark_sources"] == sources
 
     def test_returns_503_on_db_error(self, client):
         with patch(

--- a/tests/unit/test_database_routes.py
+++ b/tests/unit/test_database_routes.py
@@ -85,7 +85,9 @@ class TestDbStatus:
         with (
             patch("planner.api.routes.database._get_connection", return_value=mock_conn),
             patch("planner.api.routes.database.get_db_stats", return_value=stats),
-            patch("planner.api.routes.database._get_benchmark_source_type", return_value="postgresql"),
+            patch(
+                "planner.api.routes.database._get_benchmark_source_type", return_value="postgresql"
+            ),
         ):
             resp = client.get("/api/v1/db/status")
         assert resp.status_code == 200
@@ -101,7 +103,10 @@ class TestDbStatus:
         with (
             patch("planner.api.routes.database._get_connection", return_value=mock_conn),
             patch("planner.api.routes.database.get_db_stats", return_value=stats),
-            patch("planner.api.routes.database._get_benchmark_source_type", return_value="model_catalog"),
+            patch(
+                "planner.api.routes.database._get_benchmark_source_type",
+                return_value="model_catalog",
+            ),
             patch.dict("os.environ", {"MODEL_CATALOG_SOURCE_ID": "my_catalog"}),
         ):
             resp = client.get("/api/v1/db/status")


### PR DESCRIPTION
## Description

Surface the configured benchmark data source (`postgresql` or `model_catalog`) in the existing `GET /api/v1/db/status` response under a new `benchmark_source` key.

When the source is `model_catalog`, the response also includes `model_catalog_source_id`:
```json
{"benchmark_source": {"type": "model_catalog", "model_catalog_source_id": "redhat_ai_validated_models"}}
```

Analogously when `postgresql`, only the `type` field is present:

```json
{"benchmark_source": {"type": "postgresql"}}
```

This gives clients a lightweight way to inspect the planner's data source configuration without issuing a recommendation request (where `benchmark_metrics.source` could be used as heuristic to determine this information indirectly).

## How Has This Been Tested?

- Unit tests added covering both `postgresql` and `model_catalog` source types
- `uv run pytest tests/unit/test_database_routes.py` — all 19 tests pass
- `ruff check` passes on changed files

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work