### PR TITLE
Fix accelerator name mismatch in GPU recommendation

### DIFF
--- a/src/planner/gpu_recommender.py
+++ b/src/planner/gpu_recommender.py
@@ -16,18 +16,7 @@ from planner.capacity_planner import (
     get_text_config,
 )
 from planner.knowledge_base.model_catalog import ModelCatalog
-
-# Mapping from GPU catalog canonical names to llm_optimizer GPU_SPECS keys.
-# Most names match directly; only the A100 variants differ.
-_CATALOG_TO_OPTIMIZER: dict[str, str] = {
-    "A100-80": "A100",
-    "A100-40": "A100-40GB",
-}
-
-
-def _to_optimizer_gpu_name(catalog_name: str) -> str:
-    """Translate a catalog GPU name to the llm_optimizer GPU_SPECS key."""
-    return _CATALOG_TO_OPTIMIZER.get(catalog_name.upper(), catalog_name)
+from planner.shared.utils import catalog_to_optimizer_gpu_name
 
 
 class CostManager:
@@ -180,7 +169,7 @@ class GPURecommender:
             num_gpus = self.max_gpus_per_type.get(gpu_name, self.max_gpus)
 
             # Translate catalog GPU name to llm_optimizer's expected name
-            optimizer_gpu_name = _to_optimizer_gpu_name(gpu_name)
+            optimizer_gpu_name = catalog_to_optimizer_gpu_name(gpu_name)
 
             constraint_parts = []
             if self.max_ttft is not None:

--- a/src/planner/gpu_recommender.py
+++ b/src/planner/gpu_recommender.py
@@ -17,6 +17,18 @@ from planner.capacity_planner import (
 )
 from planner.knowledge_base.model_catalog import ModelCatalog
 
+# Mapping from GPU catalog canonical names to llm_optimizer GPU_SPECS keys.
+# Most names match directly; only the A100 variants differ.
+_CATALOG_TO_OPTIMIZER: dict[str, str] = {
+    "A100-80": "A100",
+    "A100-40": "A100-40GB",
+}
+
+
+def _to_optimizer_gpu_name(catalog_name: str) -> str:
+    """Translate a catalog GPU name to the llm_optimizer GPU_SPECS key."""
+    return _CATALOG_TO_OPTIMIZER.get(catalog_name.upper(), catalog_name)
+
 
 class CostManager:
     """Manages GPU costs using ModelCatalog as the source of truth.
@@ -167,6 +179,9 @@ class GPURecommender:
             # Use GPU-specific max_gpus if configured, otherwise use default
             num_gpus = self.max_gpus_per_type.get(gpu_name, self.max_gpus)
 
+            # Translate catalog GPU name to llm_optimizer's expected name
+            optimizer_gpu_name = _to_optimizer_gpu_name(gpu_name)
+
             constraint_parts = []
             if self.max_ttft is not None:
                 constraint_parts.append(f"ttft:p95<={self.max_ttft}ms")
@@ -180,7 +195,7 @@ class GPURecommender:
                 model=self.model_id,
                 input_len=self.input_len,
                 output_len=self.output_len,
-                gpu=gpu_name,
+                gpu=optimizer_gpu_name,
                 num_gpus=num_gpus,
                 framework="vllm",
                 target="throughput",

--- a/src/planner/recommendation/estimator.py
+++ b/src/planner/recommendation/estimator.py
@@ -18,21 +18,11 @@ from planner.gpu_recommender import GPURecommender
 from planner.knowledge_base.benchmarks import BenchmarkData, BenchmarkRepository
 from planner.knowledge_base.model_catalog import ModelCatalog
 from planner.shared.schemas import SLOTargets, TrafficProfile
+from planner.shared.utils import CATALOG_TO_OPTIMIZER_GPU
 
 logger = logging.getLogger(__name__)
 
-# Mapping from gpu_catalog.json gpu_type to llm_optimizer GPU_SPECS keys.
-# GPUs not in this map are not supported by the roofline model.
-CATALOG_TO_ROOFLINE_GPU: dict[str, str] = {
-    "H100": "H100",
-    "H200": "H200",
-    "A100-80": "A100",
-    "A100-40": "A100-40GB",
-    "L40": "L40",
-    "L20": "L20",
-    "B100": "B100",
-    "B200": "B200",
-}
+CATALOG_TO_ROOFLINE_GPU = CATALOG_TO_OPTIMIZER_GPU
 
 
 @contextlib.contextmanager

--- a/src/planner/shared/utils/__init__.py
+++ b/src/planner/shared/utils/__init__.py
@@ -1,3 +1,7 @@
 """Shared utility functions."""
 
-from .gpu_normalizer import CATALOG_TO_OPTIMIZER_GPU, catalog_to_optimizer_gpu_name, normalize_gpu_types
+from .gpu_normalizer import (
+    CATALOG_TO_OPTIMIZER_GPU,
+    catalog_to_optimizer_gpu_name,
+    normalize_gpu_types,
+)

--- a/src/planner/shared/utils/__init__.py
+++ b/src/planner/shared/utils/__init__.py
@@ -1,3 +1,3 @@
 """Shared utility functions."""
 
-from .gpu_normalizer import normalize_gpu_types
+from .gpu_normalizer import CATALOG_TO_OPTIMIZER_GPU, catalog_to_optimizer_gpu_name, normalize_gpu_types

--- a/src/planner/shared/utils/gpu_normalizer.py
+++ b/src/planner/shared/utils/gpu_normalizer.py
@@ -30,6 +30,7 @@ def catalog_to_optimizer_gpu_name(catalog_name: str) -> str:
     """
     return CATALOG_TO_OPTIMIZER_GPU.get(catalog_name, catalog_name)
 
+
 if TYPE_CHECKING:
     from planner.knowledge_base.model_catalog import ModelCatalog
 

--- a/src/planner/shared/utils/gpu_normalizer.py
+++ b/src/planner/shared/utils/gpu_normalizer.py
@@ -8,6 +8,28 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
+# Mapping from gpu_catalog.json canonical gpu_type to llm_optimizer GPU_SPECS keys.
+# GPUs not in this map are not supported by the roofline model.
+# Most names map 1:1; only the A100 variants differ.
+CATALOG_TO_OPTIMIZER_GPU: dict[str, str] = {
+    "H100": "H100",
+    "H200": "H200",
+    "A100-80": "A100",
+    "A100-40": "A100-40GB",
+    "L40": "L40",
+    "L20": "L20",
+    "B100": "B100",
+    "B200": "B200",
+}
+
+
+def catalog_to_optimizer_gpu_name(catalog_name: str) -> str:
+    """Translate a catalog GPU name to the llm_optimizer GPU_SPECS key.
+
+    Returns the original name unchanged if not in the mapping.
+    """
+    return CATALOG_TO_OPTIMIZER_GPU.get(catalog_name, catalog_name)
+
 if TYPE_CHECKING:
     from planner.knowledge_base.model_catalog import ModelCatalog
 

--- a/tests/unit/test_gpu_name_mapping.py
+++ b/tests/unit/test_gpu_name_mapping.py
@@ -1,0 +1,38 @@
+"""Tests for catalog-to-optimizer GPU name mapping."""
+
+import pytest
+
+from planner.shared.utils import CATALOG_TO_OPTIMIZER_GPU, catalog_to_optimizer_gpu_name
+
+
+@pytest.mark.unit
+class TestCatalogToOptimizerGpuName:
+    """Test catalog_to_optimizer_gpu_name translation function."""
+
+    def test_a100_80_maps_to_a100(self):
+        assert catalog_to_optimizer_gpu_name("A100-80") == "A100"
+
+    def test_a100_40_maps_to_a100_40gb(self):
+        assert catalog_to_optimizer_gpu_name("A100-40") == "A100-40GB"
+
+    def test_h100_identity(self):
+        assert catalog_to_optimizer_gpu_name("H100") == "H100"
+
+    def test_unknown_gpu_passes_through(self):
+        assert catalog_to_optimizer_gpu_name("MI300X") == "MI300X"
+
+    def test_empty_string_passes_through(self):
+        assert catalog_to_optimizer_gpu_name("") == ""
+
+
+@pytest.mark.unit
+class TestCatalogToOptimizerGpuMapping:
+    """Test the shared CATALOG_TO_OPTIMIZER_GPU mapping completeness."""
+
+    def test_contains_all_roofline_supported_gpus(self):
+        expected = {"H100", "H200", "A100-80", "A100-40", "L40", "L20", "B100", "B200"}
+        assert set(CATALOG_TO_OPTIMIZER_GPU.keys()) == expected
+
+    def test_a100_variants_differ_from_catalog_name(self):
+        assert CATALOG_TO_OPTIMIZER_GPU["A100-80"] != "A100-80"
+        assert CATALOG_TO_OPTIMIZER_GPU["A100-40"] != "A100-40"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is a mismatch between A100-40 and A100-40GB in the GPU recommender. This PR fixes name mismatch to ensure functionality. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests still pass. UI manual check was also performed. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
