### PR TITLE
feat: add P/D disaggregation output to llm-d generator

### DIFF
--- a/src/planner/api/routes/configuration.py
+++ b/src/planner/api/routes/configuration.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.concurrency import run_in_threadpool
 
 from planner.api.dependencies import (
@@ -32,6 +32,9 @@ class GenerateDeploymentRequest(BaseModel):
     configuration: DeploymentConfiguration
     namespace: str = "default"
     stack: StackType = "vllm"
+    pd_enabled: bool = False
+    prefill_replicas: int = Field(1, ge=1, le=32)
+    decode_replicas: int = Field(1, ge=1, le=32)
 
 
 class DeploymentModeRequest(BaseModel):
@@ -53,27 +56,21 @@ def _generate_yaml_from_config(
     deployment_generator: DeploymentGenerator,
     llmd_generator: LlmdDeploymentGenerator,
     yaml_validator: YAMLValidator,
+    pd_enabled: bool = False,
+    prefill_replicas: int = 1,
+    decode_replicas: int = 1,
 ) -> dict[str, Any]:
-    """Generate YAML files from a deployment configuration.
-
-    Args:
-        config: Deployment configuration
-        namespace: Kubernetes namespace
-        stack: Deployment stack (vllm or llm-d)
-        deployment_generator: vLLM deployment generator
-        llmd_generator: llm-d deployment generator
-        yaml_validator: YAML validator
-
-    Returns:
-        Dict with deployment_id, namespace, files (file paths), and contents (YAML strings)
-
-    Raises:
-        HTTPException: If stack is unknown or YAML validation fails
-    """
+    """Generate YAML files from a deployment configuration."""
     logger.info(f"Generating deployment for model: {config.model_name} (stack={stack})")
 
     if stack == "llm-d":
-        result = llmd_generator.generate_all(config=config, namespace=namespace)
+        result = llmd_generator.generate_all(
+            config=config,
+            namespace=namespace,
+            pd_enabled=pd_enabled,
+            prefill_replicas=prefill_replicas,
+            decode_replicas=decode_replicas,
+        )
     elif stack == "vllm":
         result = deployment_generator.generate_all(config=config, namespace=namespace)
     else:
@@ -132,6 +129,9 @@ async def generate_deployment(
             deployment_generator,
             llmd_generator,
             yaml_validator,
+            pd_enabled=request.pd_enabled,
+            prefill_replicas=request.prefill_replicas,
+            decode_replicas=request.decode_replicas,
         )
 
         return DeploymentBundle(

--- a/src/planner/configuration/llmd_generator.py
+++ b/src/planner/configuration/llmd_generator.py
@@ -70,19 +70,82 @@ class LlmdDeploymentGenerator:
         self,
         config: DeploymentConfiguration,
         namespace: str = "default",
+        pd_enabled: bool = False,
+        prefill_replicas: int = 1,
+        decode_replicas: int = 1,
     ) -> dict[str, Any]:
         """Generate all llm-d deployment files.
 
         Returns a dict with: deployment_id, namespace, files, contents.
+
+        When *pd_enabled* is True, separate prefill and decode patches are
+        generated instead of the single ``patch-vllm.yaml``.
         """
+        if not 1 <= prefill_replicas <= 32:
+            msg = f"prefill_replicas must be between 1 and 32, got {prefill_replicas}"
+            raise ValueError(msg)
+        if not 1 <= decode_replicas <= 32:
+            msg = f"decode_replicas must be between 1 and 32, got {decode_replicas}"
+            raise ValueError(msg)
+
         deployment_id = generate_deployment_id(config)
         context = self._prepare_context(config, deployment_id, namespace)
 
-        configs: list[tuple[str, str, str]] = [
-            ("kustomization.yaml.j2", "modelserver/kustomization.yaml", "kustomization"),
-            ("patch-vllm.yaml.j2", "modelserver/patch-vllm.yaml", "patch_vllm"),
-            ("values.yaml.j2", "scheduler/values.yaml", "helm_values"),
+        context["pd_enabled"] = pd_enabled
+
+        # Build the list of (template, output path, key, extra_context) tuples.
+        # All model-server patches use the same unified template with different
+        # deployment_name, replica_count, and extra_args.
+        patch_template = "patch-modelserver.yaml.j2"
+
+        configs: list[tuple[str, str, str, dict[str, Any]]] = [
+            ("kustomization.yaml.j2", "modelserver/kustomization.yaml", "kustomization", {}),
         ]
+
+        if pd_enabled:
+            configs.append(
+                (
+                    patch_template,
+                    "modelserver/patch-prefill.yaml",
+                    "patch_prefill",
+                    {
+                        "deployment_name": "prefill",
+                        "replica_count": prefill_replicas,
+                        "extra_args": [
+                            "--kv-connector=nixlv2",
+                            "--kv-role=kv_producer",
+                            "--enable-chunked-prefill",
+                        ],
+                    },
+                )
+            )
+            configs.append(
+                (
+                    patch_template,
+                    "modelserver/patch-decode.yaml",
+                    "patch_decode",
+                    {
+                        "deployment_name": "decode",
+                        "replica_count": decode_replicas,
+                        "extra_args": ["--kv-connector=nixlv2", "--kv-role=kv_consumer"],
+                    },
+                )
+            )
+        else:
+            configs.append(
+                (
+                    patch_template,
+                    "modelserver/patch-vllm.yaml",
+                    "patch_vllm",
+                    {
+                        "deployment_name": "decode",
+                        "replica_count": context["replicas"],
+                        "extra_args": [],
+                    },
+                )
+            )
+
+        configs.append(("values.yaml.j2", "scheduler/values.yaml", "helm_values", {}))
 
         deployment_dir = self.output_dir / deployment_id
         (deployment_dir / "modelserver").mkdir(parents=True, exist_ok=True)
@@ -91,9 +154,9 @@ class LlmdDeploymentGenerator:
         generated_files: dict[str, str] = {}
         generated_contents: dict[str, str] = {}
 
-        for template_name, output_rel_path, config_type in configs:
+        for template_name, output_rel_path, config_type, extra_ctx in configs:
             template = self.env.get_template(template_name)
-            rendered = template.render(**context)
+            rendered = template.render(**context, **extra_ctx)
 
             output_path = deployment_dir / output_rel_path
             output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/planner/configuration/templates/llmd/kustomization.yaml.j2
+++ b/src/planner/configuration/templates/llmd/kustomization.yaml.j2
@@ -39,4 +39,9 @@ labels:
         create: true
 
 patches:
+{% if pd_enabled %}
+  - path: patch-prefill.yaml
+  - path: patch-decode.yaml
+{% else %}
   - path: patch-vllm.yaml
+{% endif %}

--- a/src/planner/configuration/templates/llmd/patch-modelserver.yaml.j2
+++ b/src/planner/configuration/templates/llmd/patch-modelserver.yaml.j2
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: decode
+  name: {{ deployment_name }}
 spec:
-  replicas: {{ replicas }}
+  replicas: {{ replica_count }}
   template:
     spec:
       containers:
@@ -13,6 +13,9 @@ spec:
             - "{{ model_id }}"
             - "--tensor-parallel-size={{ tensor_parallel }}"
             - "--port=8000"
+{% for arg in extra_args %}
+            - "{{ arg }}"
+{% endfor %}
           resources:
             requests:
               nvidia.com/gpu: "{{ gpus_per_replica }}"

--- a/tests/unit/test_llmd_generator.py
+++ b/tests/unit/test_llmd_generator.py
@@ -348,3 +348,191 @@ class TestGenerateDeploymentEndpointStack:
         assert response.status_code == 200
         data = response.json()
         assert "inferenceservice" in data["files"]
+
+
+@pytest.mark.unit
+class TestPDDisaggregation:
+    """Tests for P/D (prefill/decode) disaggregation output."""
+
+    def test_pd_disabled_produces_single_patch(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """Default (pd_enabled=False) has patch_vllm, no patch_prefill/patch_decode."""
+        result = llmd_generator.generate_all(sample_config)
+
+        assert "patch_vllm" in result["contents"]
+        assert "patch_prefill" not in result["contents"]
+        assert "patch_decode" not in result["contents"]
+
+    def test_pd_disabled_patch_targets_decode_deployment(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """Non-PD patch must use name 'decode' to match the llm-d base Deployment."""
+        result = llmd_generator.generate_all(sample_config)
+        parsed = yaml.safe_load(result["contents"]["patch_vllm"])
+
+        assert parsed["metadata"]["name"] == "decode"
+
+    def test_pd_enabled_produces_prefill_and_decode_patches(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """pd_enabled=True produces patch_prefill and patch_decode, no patch_vllm."""
+        result = llmd_generator.generate_all(sample_config, pd_enabled=True)
+
+        assert "patch_prefill" in result["contents"]
+        assert "patch_decode" in result["contents"]
+        assert "patch_vllm" not in result["contents"]
+
+    def test_pd_prefill_patch_has_correct_replicas(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """Prefill patch uses prefill_replicas value."""
+        result = llmd_generator.generate_all(sample_config, pd_enabled=True, prefill_replicas=2)
+        parsed = yaml.safe_load(result["contents"]["patch_prefill"])
+
+        assert parsed["spec"]["replicas"] == 2
+        assert parsed["metadata"]["name"] == "prefill"
+
+    def test_pd_decode_patch_has_correct_replicas(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """Decode patch uses decode_replicas value."""
+        result = llmd_generator.generate_all(sample_config, pd_enabled=True, decode_replicas=3)
+        parsed = yaml.safe_load(result["contents"]["patch_decode"])
+
+        assert parsed["spec"]["replicas"] == 3
+        assert parsed["metadata"]["name"] == "decode"
+
+    def test_pd_kustomization_references_both_patches(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """Kustomization patches list has patch-prefill.yaml and patch-decode.yaml."""
+        result = llmd_generator.generate_all(sample_config, pd_enabled=True)
+        parsed = yaml.safe_load(result["contents"]["kustomization"])
+
+        patch_paths = [p["path"] for p in parsed["patches"]]
+        assert "patch-prefill.yaml" in patch_paths
+        assert "patch-decode.yaml" in patch_paths
+        assert "patch-vllm.yaml" not in patch_paths
+
+    def test_pd_all_outputs_valid_yaml(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """All contents parse as valid YAML when pd_enabled=True."""
+        result = llmd_generator.generate_all(sample_config, pd_enabled=True)
+
+        for key, content in result["contents"].items():
+            parsed = yaml.safe_load(content)
+            assert parsed is not None, f"{key} rendered as empty YAML"
+
+    def test_rejects_zero_prefill_replicas(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """generate_all() raises ValueError when prefill_replicas < 1."""
+        with pytest.raises(ValueError, match="must be between 1 and 32"):
+            llmd_generator.generate_all(sample_config, pd_enabled=True, prefill_replicas=0)
+
+    def test_rejects_zero_decode_replicas(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """generate_all() raises ValueError when decode_replicas < 1."""
+        with pytest.raises(ValueError, match="must be between 1 and 32"):
+            llmd_generator.generate_all(sample_config, pd_enabled=True, decode_replicas=0)
+
+    def test_rejects_prefill_replicas_above_max(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """generate_all() raises ValueError when prefill_replicas > 32."""
+        with pytest.raises(ValueError, match="must be between 1 and 32"):
+            llmd_generator.generate_all(sample_config, pd_enabled=True, prefill_replicas=33)
+
+    def test_rejects_decode_replicas_above_max(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """generate_all() raises ValueError when decode_replicas > 32."""
+        with pytest.raises(ValueError, match="must be between 1 and 32"):
+            llmd_generator.generate_all(sample_config, pd_enabled=True, decode_replicas=33)
+
+
+@pytest.mark.unit
+class TestDeployAPINewParams:
+    """Tests for new parameters exposed in the deploy API endpoint."""
+
+    def test_generate_deployment_llmd_with_pd_enabled(
+        self, client: TestClient, sample_config: DeploymentConfiguration
+    ) -> None:
+        """POST with pd_enabled=True should return patch_prefill and patch_decode."""
+        response = client.post(
+            "/api/v1/generate-deployment",
+            json={
+                "configuration": sample_config.model_dump(),
+                "namespace": "test-ns",
+                "stack": "llm-d",
+                "pd_enabled": True,
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "patch_prefill" in data["files"]
+        assert "patch_decode" in data["files"]
+
+    @pytest.mark.parametrize(
+        "field",
+        ["prefill_replicas", "decode_replicas"],
+    )
+    def test_generate_deployment_rejects_zero_replicas(
+        self,
+        client: TestClient,
+        sample_config: DeploymentConfiguration,
+        field: str,
+    ) -> None:
+        """API returns 422 when replica count is < 1."""
+        payload = {
+            "configuration": sample_config.model_dump(),
+            "namespace": "test-ns",
+            "stack": "llm-d",
+            "pd_enabled": True,
+            field: 0,
+        }
+        response = client.post("/api/v1/generate-deployment", json=payload)
+        assert response.status_code == 422
+
+    def test_generate_deployment_rejects_replicas_above_max(
+        self,
+        client: TestClient,
+        sample_config: DeploymentConfiguration,
+    ) -> None:
+        """API returns 422 when replica count exceeds 32."""
+        response = client.post(
+            "/api/v1/generate-deployment",
+            json={
+                "configuration": sample_config.model_dump(),
+                "namespace": "test-ns",
+                "stack": "llm-d",
+                "pd_enabled": True,
+                "prefill_replicas": 33,
+            },
+        )
+        assert response.status_code == 422

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -562,9 +562,16 @@ def deploy_to_cluster(recommendation: dict, namespace: str = "default") -> dict:
 
         stack = recommendation.get("_stack", "vllm")
 
+        payload: dict = {"configuration": config, "namespace": namespace, "stack": stack}
+        if stack == "llm-d":
+            pd_enabled = recommendation.get("_pd_enabled", False)
+            payload["pd_enabled"] = pd_enabled
+            if pd_enabled:
+                payload["prefill_replicas"] = recommendation.get("_prefill_replicas", 1)
+                payload["decode_replicas"] = recommendation.get("_decode_replicas", 1)
         gen_response = requests.post(
             f"{API_BASE_URL}/api/v1/generate-deployment",
-            json={"configuration": config, "namespace": namespace, "stack": stack},
+            json=payload,
             timeout=30,
         )
         if gen_response.status_code != 200:

--- a/ui/components/deployment.py
+++ b/ui/components/deployment.py
@@ -79,6 +79,41 @@ def render_deployment_tab():
         st.session_state.deployment_error = None
         st.rerun()
 
+    # P/D disaggregation options (llm-d only)
+    if stack == "llm-d":
+        pd_enabled = st.checkbox(
+            "Enable P/D Disaggregation",
+            value=st.session_state.get("pd_enabled", False),
+            key="pd_enabled",
+            help="Generate separate prefill and decode deployments for latency-sensitive workloads.",
+        )
+        if pd_enabled != st.session_state.get("_prev_pd_enabled", False):
+            st.session_state._prev_pd_enabled = pd_enabled
+            if st.session_state.get("deployment_yaml_generated"):
+                st.session_state.deployment_yaml_generated = False
+                st.session_state.deployment_yaml_files = {}
+                st.session_state.deployment_id = None
+                st.session_state.deployment_error = None
+                st.rerun()
+        if pd_enabled:
+            col1, col2 = st.columns(2)
+            with col1:
+                st.number_input(
+                    "Prefill Replicas",
+                    min_value=1,
+                    max_value=32,
+                    value=st.session_state.get("prefill_replicas", 1),
+                    key="prefill_replicas",
+                )
+            with col2:
+                st.number_input(
+                    "Decode Replicas",
+                    min_value=1,
+                    max_value=32,
+                    value=st.session_state.get("decode_replicas", 1),
+                    key="decode_replicas",
+                )
+
     # YAML Generation Section
     if not st.session_state.get("deployment_yaml_generated"):
         st.subheader("Deployment Files")
@@ -92,13 +127,22 @@ def render_deployment_tab():
                     if not configuration:
                         st.error("Selected configuration is missing deployment configuration data.")
                         return
+                    payload: dict = {
+                        "configuration": configuration,
+                        "namespace": "default",
+                        "stack": stack,
+                    }
+                    if stack == "llm-d":
+                        pd_enabled = st.session_state.get("pd_enabled", False)
+                        payload["pd_enabled"] = pd_enabled
+                        if pd_enabled:
+                            payload["prefill_replicas"] = st.session_state.get(
+                                "prefill_replicas", 1
+                            )
+                            payload["decode_replicas"] = st.session_state.get("decode_replicas", 1)
                     response = requests.post(
                         f"{API_BASE_URL}/api/v1/generate-deployment",
-                        json={
-                            "configuration": configuration,
-                            "namespace": "default",
-                            "stack": stack,
-                        },
+                        json=payload,
                         timeout=30,
                     )
                     response.raise_for_status()
@@ -165,10 +209,18 @@ def render_deployment_tab():
         if yaml_files:
             stack = st.session_state.get("deployment_stack", "vllm")
             if stack == "llm-d":
-                file_order = ["kustomization", "patch_vllm", "helm_values"]
+                file_order = [
+                    "kustomization",
+                    "patch_vllm",
+                    "patch_prefill",
+                    "patch_decode",
+                    "helm_values",
+                ]
                 file_labels = {
                     "kustomization": "Kustomization (Model Server)",
                     "patch_vllm": "vLLM Patch (Model Server)",
+                    "patch_prefill": "Prefill Patch (Model Server)",
+                    "patch_decode": "Decode Patch (Model Server)",
                     "helm_values": "Helm Values (EPP + InferencePool)",
                 }
             else:
@@ -218,8 +270,16 @@ def _render_deploy_to_cluster_button(selected_config: dict):
             )
             return
 
+        deploy_config = dict(selected_config)
+        deploy_config["_stack"] = st.session_state.get("deployment_stack", "vllm")
+        if deploy_config["_stack"] == "llm-d":
+            deploy_config["_pd_enabled"] = st.session_state.get("pd_enabled", False)
+            if deploy_config["_pd_enabled"]:
+                deploy_config["_prefill_replicas"] = st.session_state.get("prefill_replicas", 1)
+                deploy_config["_decode_replicas"] = st.session_state.get("decode_replicas", 1)
+
         with st.spinner("Deploying to Kubernetes cluster..."):
-            result = deploy_to_cluster(selected_config)
+            result = deploy_to_cluster(deploy_config)
 
         if result.get("success") or result.get("deployment_id"):
             st.session_state.deployed_to_cluster = True


### PR DESCRIPTION
## Description

Adds prefill/decode (P/D) disaggregation as an output option to the llm-d deployment generator. When P/D is enabled, the generator produces separate Kustomize patches for prefill and decode deployments instead of the single _patch-vllm.yaml_, allowing users to configure independent replica counts and vLLM arguments for each role.

When `pd_enabled=False` (the default), output is identical to the current behavior introduced in PR #274. No breaking changes.

### What gets generated when P/D is enabled

- _patch-prefill.yaml_ - Prefill deployment with `--kv-role=kv_producer`, `--enable-chunked-prefill`, and configurable `prefill_replicas`
- _patch-decode.yaml_ - Decode deployment with `--kv-role=kv_consumer` and configurable `decode_replicas`
- _kustomization.yaml_ - Conditionally references prefill + decode patches instead of the single vLLM patch
- _values.yaml_ - EPP Helm values (unchanged)

KV transfer uses `nixlv2` (`NixlConnector`) with separate `--kv-connector` and `--kv-role` args, matching the llm-d P/D well-lit path.

### Template consolidation

All three patch templates (patch-vllm, patch-prefill, patch-decode) are consolidated into a single `patch-modelserver.yaml.j2` rendered with different context variables (`deployment_name`, `replica_count`, `extra_args`). This avoids maintaining three near-identical templates that would drift independently. Role-specific differences (_e.g._, kv-connector args, chunked-prefill) are passed as `extra_args` from the generator code. If the prefill and decode roles diverge significantly in the future (different sidecars, volumes, probes), splitting back into separate templates is a one-step refactor.

### Changes

- **_src/planner/configuration/templates/llmd/patch-modelserver.yaml.j2_** - Unified template for all model-server patches (replaces patch-vllm, patch-prefill, patch-decode).
- **_src/planner/configuration/llmd_generator.py_** - `generate_all()` accepts `pd_enabled`, `prefill_replicas`, and `decode_replicas` parameters. Renders the unified template with role-specific context. Validates replica counts >= 1 at the generator level (raises `ValueError`).
- **_src/planner/configuration/templates/llmd/kustomization.yaml.j2_** - Conditional patch references based on `pd_enabled`.
- **_src/planner/api/routes/configuration.py_** - Added `pd_enabled`, `prefill_replicas`, and `decode_replicas` fields to `DeploymentRequest` with `Field(ge=1, le=32)` validation on replica counts.
- **_ui/components/deployment.py_** - Added "Enable P/D Disaggregation" checkbox with prefill/decode replica inputs (shown when enabled, llm-d stack only). File display section handles `patch_prefill`/`patch_decode` keys.
- **_tests/unit/test_llmd_generator.py_** - Added `TestPDDisaggregation` (8 tests), `TestDeployAPINewParams` (4 tests). 31 tests total.

**Note on `deployment_name`**: The non-PD patch uses `metadata.name: decode` (not `vllm`) because it is a strategic merge patch targeting the upstream llm-d base `Deployment/decode`. A dedicated test locks this down.

## How Has This Been Tested?

12 new unit tests added, full suite passes (31 tests in test_llmd_generator.py):

```bash
cd src && uv run pytest ../tests/unit/test_llmd_generator.py -v
```

Tests cover:
- `test_pd_disabled_produces_single_patch` - Default behavior unchanged: `patch_vllm` present, no `patch_prefill`/`patch_decode`.
- `test_pd_disabled_patch_targets_decode_deployment` - Non-PD patch uses `metadata.name: decode` to match the llm-d base Deployment.
- `test_pd_enabled_produces_prefill_and_decode_patches` - P/D mode produces `patch_prefill` and `patch_decode`, no `patch_vllm`.
- `test_pd_prefill_patch_has_correct_replicas` - Prefill patch uses `prefill_replicas` value (non-default) and has `metadata.name: prefill`.
- `test_pd_decode_patch_has_correct_replicas` - Decode patch uses `decode_replicas` value and has `metadata.name: decode`.
- `test_pd_kustomization_references_both_patches` - Kustomization patches list contains _patch-prefill.yaml_ and _patch-decode.yaml_, not _patch-vllm.yaml_.
- `test_pd_all_outputs_valid_yaml` - All generated contents parse as valid YAML.
- `test_rejects_zero_replicas` (parametrized) - Generator raises `ValueError` when `prefill_replicas` or `decode_replicas` < 1.
- `test_deploy_llmd_with_pd_enabled` - API integration test: POST with `pd_enabled: true` returns `200` with `patch_prefill` and `patch_decode`.
- `test_deploy_rejects_zero_replicas` (parametrized) - API returns 422 when `prefill_replicas` or `decode_replicas` is 0.
- `test_deploy_rejects_replicas_above_max` - API returns 422 when replica count exceeds 32.

UI manually tested: selecting llm-d stack and enabling the P/D checkbox shows prefill/decode replica inputs; generated files display correctly with the new file labels.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work