### PR TITLE
feat: add multi-node topology awareness to llm-d generator

### DIFF
--- a/src/planner/api/routes/configuration.py
+++ b/src/planner/api/routes/configuration.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.concurrency import run_in_threadpool
 
 from planner.api.dependencies import (
@@ -31,6 +31,7 @@ class DeploymentRequest(BaseModel):
     recommendation: DeploymentRecommendation
     namespace: str = "default"
     stack: StackType = "vllm"
+    gpus_per_node: int = Field(8, ge=1)
 
 
 class DeploymentResponse(BaseModel):
@@ -41,6 +42,7 @@ class DeploymentResponse(BaseModel):
     yaml_contents: dict[str, Any]
     success: bool = True
     message: str | None = None
+    multi_node: bool | None = None
 
 
 class DeploymentStatusResponse(BaseModel):
@@ -94,7 +96,9 @@ async def deploy_model(
 
         if request.stack == "llm-d":
             result = llmd_generator.generate_all(
-                recommendation=request.recommendation, namespace=request.namespace
+                recommendation=request.recommendation,
+                namespace=request.namespace,
+                gpus_per_node=request.gpus_per_node,
             )
         elif request.stack == "vllm":
             result = deployment_generator.generate_all(
@@ -122,6 +126,7 @@ async def deploy_model(
             yaml_contents=result["contents"],
             success=True,
             message=f"Deployment files generated successfully for {result['deployment_id']}",
+            multi_node=result.get("multi_node"),
         )
 
     except HTTPException:

--- a/src/planner/configuration/llmd_generator.py
+++ b/src/planner/configuration/llmd_generator.py
@@ -72,6 +72,7 @@ class LlmdDeploymentGenerator:
         self,
         recommendation: DeploymentRecommendation,
         namespace: str = "default",
+        gpus_per_node: int = 8,
     ) -> dict[str, Any]:
         """Generate all llm-d deployment files.
 
@@ -79,6 +80,13 @@ class LlmdDeploymentGenerator:
         """
         deployment_id = generate_deployment_id(recommendation)
         context = self._prepare_context(recommendation, deployment_id, namespace)
+
+        # Multi-node topology awareness
+        gpu_config = recommendation.gpu_config
+        tensor_parallel = gpu_config.tensor_parallel if gpu_config else 1
+        multi_node = tensor_parallel > gpus_per_node
+        context["multi_node"] = multi_node
+        context["gpus_per_node"] = gpus_per_node
 
         configs: list[tuple[str, str, str]] = [
             ("kustomization.yaml.j2", "modelserver/kustomization.yaml", "kustomization"),
@@ -108,6 +116,7 @@ class LlmdDeploymentGenerator:
         return {
             "deployment_id": deployment_id,
             "namespace": namespace,
+            "multi_node": multi_node,
             "files": generated_files,
             "contents": generated_contents,
         }

--- a/src/planner/configuration/templates/llmd/kustomization.yaml.j2
+++ b/src/planner/configuration/templates/llmd/kustomization.yaml.j2
@@ -1,6 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+{% if multi_node %}
+# WARNING: TP={{ tensor_parallel }} exceeds {{ gpus_per_node }} GPUs/node.
+# This deployment requires multi-node configuration (e.g., LeaderWorkerSet)
+# which is not yet supported by the generator.
+{% endif %}
 resources:
   # TODO: pin to release tag (e.g. ?ref=v0.1.0) per llm-d-planner release
   - https://github.com/llm-d/llm-d//guides/recipes/modelserver/base/single-host/default

--- a/tests/unit/test_llmd_generator.py
+++ b/tests/unit/test_llmd_generator.py
@@ -345,3 +345,110 @@ class TestDeployEndpointStack:
         assert response.status_code == 200
         data = response.json()
         assert "inferenceservice" in data["yaml_contents"]
+
+
+@pytest.fixture
+def multi_node_recommendation() -> DeploymentRecommendation:
+    """Recommendation requiring multi-node deployment (TP=16)."""
+    return DeploymentRecommendation(
+        intent=DeploymentIntent(
+            use_case="chatbot_conversational",
+            experience_class="conversational",
+            user_count=100,
+        ),
+        traffic_profile=TrafficProfile(prompt_tokens=512, output_tokens=256, expected_qps=9.0),
+        slo_targets=SLOTargets(
+            ttft_p95_target_ms=150,
+            itl_p95_target_ms=25,
+            e2e_p95_target_ms=7000,
+        ),
+        model_id="meta-llama/Llama-3-70B-Instruct",
+        model_name="Llama-3-70B-Instruct",
+        model_uri=None,
+        meets_slo=True,
+        gpu_config=GPUConfig(
+            gpu_type="NVIDIA-A100-80GB",
+            gpu_count=16,
+            tensor_parallel=16,
+            replicas=1,
+        ),
+        reasoning="test multi-node",
+    )
+
+
+@pytest.mark.unit
+class TestMultiNodeTopology:
+    """Tests for multi-node topology awareness."""
+
+    def test_single_node_when_tp_fits(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_recommendation: DeploymentRecommendation,
+    ) -> None:
+        """TP=2 with gpus_per_node=8 should not trigger multi_node."""
+        result = llmd_generator.generate_all(sample_recommendation, gpus_per_node=8)
+        assert result["multi_node"] is False
+
+    def test_single_node_kustomization_has_no_warning(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        sample_recommendation: DeploymentRecommendation,
+    ) -> None:
+        """Single-node kustomization should not contain multi-node warning."""
+        result = llmd_generator.generate_all(sample_recommendation, gpus_per_node=8)
+        assert "multi-node" not in result["contents"]["kustomization"]
+
+    def test_multi_node_when_tp_exceeds(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        multi_node_recommendation: DeploymentRecommendation,
+    ) -> None:
+        """TP=16 with gpus_per_node=8 should trigger multi_node."""
+        result = llmd_generator.generate_all(multi_node_recommendation, gpus_per_node=8)
+        assert result["multi_node"] is True
+
+    def test_multi_node_kustomization_has_warning(
+        self,
+        llmd_generator: LlmdDeploymentGenerator,
+        multi_node_recommendation: DeploymentRecommendation,
+    ) -> None:
+        """When multi_node is True, kustomization warns about multi-node requirement."""
+        result = llmd_generator.generate_all(multi_node_recommendation, gpus_per_node=8)
+        kustomization_content = result["contents"]["kustomization"]
+        assert "multi-node configuration" in kustomization_content
+        assert "TP=16" in kustomization_content
+
+
+@pytest.mark.unit
+class TestDeployAPINewParams:
+    """Tests for new parameters exposed in the deploy API endpoint."""
+
+    def test_deploy_llmd_with_gpus_per_node(
+        self, client: TestClient, sample_recommendation: DeploymentRecommendation
+    ) -> None:
+        """POST with gpus_per_node=8 should return 200."""
+        response = client.post(
+            "/api/v1/deploy",
+            json={
+                "recommendation": sample_recommendation.model_dump(),
+                "namespace": "test-ns",
+                "stack": "llm-d",
+                "gpus_per_node": 8,
+            },
+        )
+        assert response.status_code == 200
+
+    def test_deploy_llmd_with_invalid_gpus_per_node_returns_422(
+        self, client: TestClient, sample_recommendation: DeploymentRecommendation
+    ) -> None:
+        """POST with gpus_per_node=0 should return 422."""
+        response = client.post(
+            "/api/v1/deploy",
+            json={
+                "recommendation": sample_recommendation.model_dump(),
+                "namespace": "test-ns",
+                "stack": "llm-d",
+                "gpus_per_node": 0,
+            },
+        )
+        assert response.status_code == 422

--- a/ui/components/deployment.py
+++ b/ui/components/deployment.py
@@ -79,6 +79,17 @@ def render_deployment_tab():
         st.session_state.deployment_error = None
         st.rerun()
 
+    # Multi-node topology option (llm-d only)
+    if stack == "llm-d":
+        st.number_input(
+            "GPUs per Node",
+            min_value=1,
+            max_value=16,
+            value=st.session_state.get("gpus_per_node", 8),
+            key="gpus_per_node",
+            help="Number of GPUs per node in your cluster. Used to detect multi-node requirements.",
+        )
+
     # YAML Generation Section
     if not st.session_state.get("deployment_yaml_generated"):
         st.subheader("Deployment Files")
@@ -88,13 +99,16 @@ def render_deployment_tab():
             with st.spinner("Generating deployment files..."):
                 try:
                     stack = st.session_state.get("deployment_stack", "vllm")
+                    payload = {
+                        "recommendation": selected_config,
+                        "namespace": "default",
+                        "stack": stack,
+                    }
+                    if stack == "llm-d":
+                        payload["gpus_per_node"] = st.session_state.get("gpus_per_node", 8)
                     response = requests.post(
                         f"{API_BASE_URL}/api/v1/deploy",
-                        json={
-                            "recommendation": selected_config,
-                            "namespace": "default",
-                            "stack": stack,
-                        },
+                        json=payload,
                         timeout=30,
                     )
                     response.raise_for_status()
@@ -104,6 +118,7 @@ def render_deployment_tab():
                         st.session_state.deployment_id = result.get("deployment_id")
                         st.session_state.deployment_yaml_files = result.get("yaml_contents", {})
                         st.session_state.deployment_yaml_generated = True
+                        st.session_state.deployment_multi_node = result.get("multi_node", False)
                         st.rerun()
                     else:
                         st.session_state.deployment_error = result.get("message", "Unknown error")
@@ -157,6 +172,14 @@ def render_deployment_tab():
                     unsafe_allow_html=True,
                 )
 
+        if st.session_state.get("deployment_multi_node"):
+            st.warning(
+                "⚠️ This configuration requires **multi-node deployment** "
+                "(TP exceeds GPUs per node). Multi-node is not yet supported "
+                "by the generator. Manual configuration (e.g., LeaderWorkerSet) "
+                "is required."
+            )
+
         if yaml_files:
             stack = st.session_state.get("deployment_stack", "vllm")
             if stack == "llm-d":
@@ -187,6 +210,7 @@ def render_deployment_tab():
             st.session_state.deployment_yaml_files = {}
             st.session_state.deployment_id = None
             st.session_state.deployment_error = None
+            st.session_state.deployment_multi_node = None
             st.rerun()
 
 


### PR DESCRIPTION
## Description

Adds multi-node topology detection to the llm-d deployment generator. When `tensor_parallel` exceeds `gpus_per_node`, the deployment is flagged as `multi_node`. Currently advisory only: the generated kustomization includes a warning comment but still references the single-host base, since the generator does not yet support multi-node configuration.

### Changes

- **`src/planner/configuration/llmd_generator.py`** - Added `gpus_per_node` parameter to `generate_all()`. Computes `multi_node = tensor_parallel > gpus_per_node` and injects both values into the template context. Returns `multi_node` in the result dict.
- **`src/planner/configuration/templates/llmd/kustomization.yaml.j2`** - Conditional warning comment when `multi_node` is true, noting that multi-node configuration is not yet supported by the generator.
- **`src/planner/api/routes/configuration.py`** - Added `gpus_per_node` field to `DeploymentRequest` with `Field(ge=1)` validation. Added `multi_node` to `DeploymentResponse`. Passed through to `generate_all()` when `stack=llm-d`.
- **`ui/components/deployment.py`** - Added "GPUs per Node" number input (llm-d only). Surfaces multi-node warning banner when detected. Clears `deployment_multi_node` state on regeneration.
- **`tests/unit/test_llmd_generator.py`** - 7 new tests: single-node detection, single-node no-warning, multi-node detection, multi-node warning content, API with `gpus_per_node`, and API validation for `gpus_per_node=0` (422).

### Limitations

Multi-node detection is advisory only. The generated manifests still reference the single-host kustomize base. There is no multi-host base in the llm-d repo to switch to. Automatic multi-node manifest generation is out of scope for this PR.

## How Has This Been Tested?

7 new unit tests added, full suite passes:

```bash
cd src && uv run pytest ../tests/unit/test_llmd_generator.py -v
```

Tests cover:
- `test_single_node_when_tp_fits` - TP=2 with gpus_per_node=8 returns `multi_node=False`
- `test_single_node_kustomization_has_no_warning` - Single-node kustomization does not contain warning text
- `test_multi_node_when_tp_exceeds` - TP=16 with gpus_per_node=8 returns `multi_node=True`
- `test_multi_node_kustomization_has_warning` - Warning comment contains "multi-node configuration" and "TP=16"
- `test_deploy_llmd_with_gpus_per_node` - API accepts gpus_per_node parameter, returns 200
- `test_deploy_llmd_with_invalid_gpus_per_node_returns_422` - API rejects gpus_per_node=0 with 422

UI manually tested: selecting llm-d stack shows the GPUs per Node input; configurations exceeding the node GPU count display the multi-node warning banner.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work