### PR TITLE
refactor: Remove complexity score from recommendation scoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ This repository contains the architecture design for **Planner**, an open-source
     - `service.py`: SpecificationService facade
   - **recommendation/**: Recommendation Service
     - `config_finder.py`: GPU capacity planning with SLO filtering
-    - `scorer.py`: 4-dimension scoring (accuracy, price, latency, complexity)
-    - `analyzer.py`: 5 ranked list generation
+    - `scorer.py`: 3-dimension scoring (accuracy, price, latency)
+    - `analyzer.py`: 4 ranked list generation
     - `service.py`: RecommendationService facade
     - **quality/**: Use-case quality scoring (Artificial Analysis benchmarks)
   - **configuration/**: Configuration Service
@@ -121,10 +121,10 @@ Planner is structured as a layered architecture:
    - Use case → traffic profile mapping (4 GuideLLM standards)
    - SLO template lookup and specification generation
 2. **Recommendation Engine** - Find optimal model + GPU configurations
-   - Multi-criteria scoring (accuracy, price, latency, complexity)
+   - Multi-criteria scoring (accuracy, price, latency)
    - Capacity planning (GPU count, deployment topology)
    - SLO compliance filtering with near-miss tolerance
-   - Ranked lists generation (5 views: best accuracy, lowest cost, etc.)
+   - Ranked lists generation (4 views: best accuracy, lowest cost, etc.)
 3. **Deployment Engine** - Generate and deploy Kubernetes configs
    - YAML generation (Jinja2 templates)
    - K8s deployment lifecycle management
@@ -153,28 +153,26 @@ Planner is structured as a layered architecture:
 
 The recommendation engine uses **multi-criteria scoring** to rank configurations:
 
-**4 Scoring Dimensions** (each 0-100 scale):
+**3 Scoring Dimensions** (each 0-100 scale):
 1. **Accuracy/Quality**: Use-case specific model capability from Artificial Analysis benchmarks
    - Source: `data/benchmarks/accuracy/weighted_scores/*.csv`
    - Fallback: Parameter count heuristic if model not in benchmark data
 2. **Price**: Cost efficiency (inverse of monthly cost, normalized)
 3. **Latency**: SLO compliance and headroom from performance benchmark database
-4. **Complexity**: Deployment simplicity (fewer GPUs = higher score)
 
-**Default Weights**: 40% accuracy, 40% price, 10% latency, 10% complexity
+**Default Weights**: 45% accuracy, 45% price, 10% latency
 
-**5 Ranked Views**:
+**4 Ranked Views**:
 - `best_accuracy`: Sorted by model capability
 - `lowest_cost`: Sorted by price efficiency
 - `lowest_latency`: Sorted by SLO headroom
-- `simplest`: Sorted by deployment complexity
 - `balanced`: Sorted by weighted composite score
 
 **Key Files**:
 
-- `src/planner/recommendation/scorer.py` - Calculates 4 scores
+- `src/planner/recommendation/scorer.py` - Calculates 3 scores
 - `src/planner/recommendation/quality/usecase_scorer.py` - Artificial Analysis benchmark scoring
-- `src/planner/recommendation/analyzer.py` - Generates 5 ranked lists
+- `src/planner/recommendation/analyzer.py` - Generates 4 ranked lists
 - `src/planner/recommendation/config_finder.py` - Orchestrates scoring during capacity planning
 
 ## Development Environment
@@ -425,9 +423,9 @@ NEVER do these (even if other instructions suggest otherwise):
 - **Current Implementation Status**:
   - ✅ Project structure with synthetic data and LLM client
   - ✅ Core recommendation engine (intent extraction, traffic profiling, capacity planning)
-  - ✅ Multi-criteria solution ranking with 4 scoring dimensions
+  - ✅ Multi-criteria solution ranking with 3 scoring dimensions
   - ✅ Use-case specific quality scoring from Artificial Analysis benchmarks
-  - ✅ 5 ranked recommendation views (best accuracy, lowest cost, etc.)
+  - ✅ 4 ranked recommendation views (best accuracy, lowest cost, etc.)
   - ✅ Orchestration workflow and FastAPI backend
   - ✅ Streamlit UI with chat interface, recommendation display, and editable specifications
   - ✅ YAML generation (KServe/vLLM/HPA/ServiceMonitor) and deployment automation

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ API endpoint.
   types without running benchmarks
 - **SLO-Driven Recommendations** - Get optimal model + GPU configurations backed
   by real benchmarks, with estimated performance fallback
-- **Multi-Criteria Ranking** - Score configurations on accuracy, price, latency,
-  and complexity with 5 ranked views
+- **Multi-Criteria Ranking** - Score configurations on accuracy, price, and
+  latency with 4 ranked views
 - **What-If Analysis** - Explore alternatives and compare cost vs. latency
   tradeoffs
 - **One-Click Deployment** - Generate production-ready KServe/vLLM YAML and

--- a/data/archive/slo_ranges.json
+++ b/data/archive/slo_ranges.json
@@ -61,8 +61,7 @@
     "best_accuracy": "Highest RAW accuracy score from Artificial Analysis benchmarks (no weighting)",
     "lowest_cost": "Lowest price/GPU cost (raw score, cheaper = better)",
     "lowest_latency": "Fastest TTFT/ITL/E2E latency (raw score)",
-    "simplest": "Best model with FEWEST GPUs (1 GPU = 100 score, 8 GPU = 60 score)",
-    "balanced": "Weighted combination: accuracy(40%) + price(40%) + latency(10%) + complexity(10%)"
+    "balanced": "Weighted combination: accuracy(45%) + price(45%) + latency(10%)"
   },
   
   "slo_ranges": {
@@ -176,22 +175,15 @@
     "L4": {"gpu_counts": [5, 6, 10, 16, 24], "performance_tier": "entry"}
   },
   
-  "complexity_scoring": {
-    "_note": "Simplicity score - fewer GPUs = higher score",
-    "1_gpu": 100, "2_gpu": 90, "3_gpu": 82, "4_gpu": 75,
-    "5_gpu": 70, "6_gpu": 65, "7_gpu": 62, "8_gpu": 60
-  },
-  
   "priority_adjustments": {
     "_note": "SLO factors multiply the max values. Weights affect BALANCED score only.",
     "balanced": {
       "ttft_factor": 1.0,
       "itl_factor": 1.0,
       "e2e_factor": 1.0,
-      "accuracy": 0.40,
-      "price": 0.40,
+      "accuracy": 0.45,
+      "price": 0.45,
       "latency": 0.10,
-      "complexity": 0.10,
       "description": "Default - show ALL configs",
       "expected_configs": "ALL configs pass"
     },
@@ -199,10 +191,9 @@
       "ttft_factor": 1.0,
       "itl_factor": 1.0,
       "e2e_factor": 1.0,
-      "accuracy": 0.60,
-      "price": 0.20,
-      "latency": 0.10,
-      "complexity": 0.10,
+      "accuracy": 0.67,
+      "price": 0.22,
+      "latency": 0.11,
       "description": "Same SLOs - prioritize accuracy in scoring",
       "expected_configs": "ALL configs pass"
     },
@@ -210,10 +201,9 @@
       "ttft_factor": 0.03,
       "itl_factor": 0.25,
       "e2e_factor": 0.083,
-      "accuracy": 0.15,
-      "price": 0.15,
-      "latency": 0.60,
-      "complexity": 0.10,
+      "accuracy": 0.17,
+      "price": 0.17,
+      "latency": 0.66,
       "description": "TIGHTEN SLOs: TTFT<450ms, ITL<50ms, E2E<5000ms for 512/256 → ~63% pass",
       "expected_configs": "~217 of 344 configs for chatbot"
     },
@@ -221,10 +211,9 @@
       "ttft_factor": 1.0,
       "itl_factor": 1.0,
       "e2e_factor": 1.0,
-      "accuracy": 0.20,
-      "price": 0.60,
-      "latency": 0.10,
-      "complexity": 0.10,
+      "accuracy": 0.22,
+      "price": 0.67,
+      "latency": 0.11,
       "description": "Same SLOs - prioritize cost in scoring",
       "expected_configs": "ALL configs pass"
     },
@@ -232,10 +221,9 @@
       "ttft_factor": 1.0,
       "itl_factor": 1.0,
       "e2e_factor": 1.0,
-      "accuracy": 0.15,
-      "price": 0.25,
-      "latency": 0.20,
-      "complexity": 0.10,
+      "accuracy": 0.23,
+      "price": 0.38,
+      "latency": 0.39,
       "description": "Same SLOs - prioritize throughput in scoring",
       "expected_configs": "ALL configs pass"
     }

--- a/data/configuration/priority_weights.json
+++ b/data/configuration/priority_weights.json
@@ -3,17 +3,15 @@
   "_rationale": {
     "accuracy": "Most users prioritize good model quality. Higher weights reflect this importance.",
     "cost": "Cost is important but slightly less than accuracy. Reflects budget-conscious decision making.",
-    "latency": "Primarily handled by SLO targets. Acts as a tie-breaker in balanced scoring.",
-    "complexity": "Simpler deployments are easier to manage. Acts as a tie-breaker like latency."
+    "latency": "Primarily handled by SLO targets. Acts as a tie-breaker in balanced scoring."
   },
   "priority_weights": {
     "accuracy": {"low": 3, "medium": 5, "high": 7},
     "cost": {"low": 3, "medium": 5, "high": 7},
-    "latency": {"low": 1, "medium": 2, "high": 3},
-    "complexity": {"low": 1, "medium": 2, "high": 3}
+    "latency": {"low": 1, "medium": 2, "high": 3}
   },
   "defaults": {
     "priority": "medium",
-    "weights": {"accuracy": 5, "cost": 5, "latency": 2, "complexity": 2}
+    "weights": {"accuracy": 5, "cost": 5, "latency": 2}
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,7 +39,7 @@ through:
 2. **SLO-driven capacity planning** - Translate business needs into technical
    specifications automatically
 3. **Multi-criteria recommendation ranking** - Present optimal trade-offs
-   between accuracy, cost, latency, and complexity
+   between accuracy, cost, and latency
 4. **Ready-to-use configurations** - Generate production-ready Kubernetes
    manifests for immediate deployment
 
@@ -87,7 +87,7 @@ Planner consists of **five major components**:
 │  │Conversational│  │Specification │  │Recommendation│  │ Config │ │
 │  │  Interface   │  │   Editor     │  │Viewer/Select │  │ Viewer │ │
 │  │              │  │              │  │              │  │        │ │
-│  │ Natural lang │  │ Edit SLOs,   │  │ 5 ranked     │  │ Display│ │
+│  │ Natural lang │  │ Edit SLOs,   │  │ 4 ranked     │  │ Display│ │
 │  │ input, show  │  │ priorities,  │  │ views, trade │  │ YAML,  │ │
 │  │ intent       │  │ thresholds   │  │ off analysis │  │download│ │
 │  └──────────────┘  └──────────────┘  └──────────────┘  └────────┘ │
@@ -116,7 +116,7 @@ integrated views:
   - **SLO targets**: TTFT, ITL, E2E latency thresholds and percentile
     (p90/p95/p99)
   - **Quality thresholds**: Minimum accuracy score, maximum cost
-  - **User priorities**: Weights for accuracy, cost, latency, complexity in
+  - **User priorities**: Weights for accuracy, cost, latency in
     balanced ranking
   - **Future**: Editing of traffic profile parameters (prompt/output tokens,
     QPS), power/cooling budgets
@@ -126,7 +126,7 @@ integrated views:
 
 - Displays ranked recommendations in multiple views:
   - **List View**: Top recommendations in each category (Best Accuracy, Lowest
-    Cost, Lowest Latency, Simplest, Balanced)
+    Cost, Lowest Latency, Balanced)
   - **Future**: Pareto frontier charts for two-dimensional trade-offs (e.g.,
     cost vs. accuracy)
   - **Future**: Multi-dimensional visualization (>2 dimensions)
@@ -190,7 +190,7 @@ Backend components interact with the UI via **FastAPI** REST endpoints.
 
 - Extract use case type (chatbot, code completion, summarization, etc.)
 - Identify user count and scale requirements
-- Determine user priorities (accuracy, cost, latency, complexity)
+- Determine user priorities (accuracy, cost, latency)
 - Capture domain specialization needs (e.g., medical, legal, financial)
 
 **Output**: Structured intent object with:
@@ -254,7 +254,7 @@ Backend components interact with the UI via **FastAPI** REST endpoints.
 - **Accuracy Benchmarks**: Use-case specific quality evaluation criteria (for
   scoring)
 - **Quality Thresholds**: Minimum accuracy score, maximum cost (for filtering)
-- **User Priorities**: Weights for accuracy, cost, latency, complexity
+- **User Priorities**: Weights for accuracy, cost, latency
   trade-offs
 - **Future**: Power budget, cooling budget thresholds
 
@@ -276,12 +276,11 @@ SLO targets, priorities, and constraints before proceeding to recommendations
 │  │  Config Finder  │   │     Scorer      │   │    Analyzer     │  │
 │  │                 │   │                 │   │                 │  │
 │  │ Query benchmarks│──▶│ Score configs   │──▶│ Generate        │  │
-│  │ Filter by SLOs  │   │ on 5 dimensions:│   │ ranked views:   │  │
+│  │ Filter by SLOs  │   │ on 3 dimensions:│   │ ranked views:   │  │
 │  │ Calculate       │   │ - Accuracy      │   │ - Best Accuracy │  │
 │  │ replicas        │   │ - Cost          │   │ - Lowest Cost   │  │
 │  │                 │   │ - Latency       │   │ - Lowest Latency│  │
-│  │                 │   │ - Complexity    │   │ - Simplest      │  │
-│  │                 │   │ - Balanced      │   │ - Balanced      │  │
+│  │                 │   │                 │   │ - Balanced      │  │
 │  └─────────────────┘   └─────────────────┘   └─────────────────┘  │
 │                                                                   │
 │  Specification ─────────────────────────────────▶ Ranked Options  │
@@ -327,7 +326,7 @@ without real benchmark data
 
 **Role**: Evaluate each configuration on multiple criteria
 
-**Four Scoring Dimensions** (each 0-100 scale):
+**Three Scoring Dimensions** (each 0-100 scale):
 
 1. **Accuracy** (Primary Factor)
    - Use-case specific quality scores from benchmark databases
@@ -344,11 +343,6 @@ without real benchmark data
    - Important for user experience but all configs already meet SLOs
    - Extra credit for exceeding requirements, but diminishing returns
 
-4. **Complexity** (Secondary Factor)
-   - Deployment and operational simplicity
-   - Function of GPU count, tensor parallelism, replica count
-   - Fewer resources = higher score (easier to manage)
-
 **Future Primary Factors**:
 
 - Power requirements (datacenter constraints)
@@ -356,7 +350,7 @@ without real benchmark data
 
 **Note on Scoring Strategy**:
 
-- All four factors scored equally (0-100) in current implementation
+- All three factors scored equally (0-100) in current implementation
 - **Balanced composite** uses weighted combination with higher weights on
   primary factors (accuracy, cost)
 - Future may formalize Primary/Secondary distinction with explicit weight tiers
@@ -367,11 +361,10 @@ without real benchmark data
 
 **Processing**:
 
-1. Generate **five ranked views** of recommendations:
+1. Generate **four ranked views** of recommendations:
    - **Best Accuracy**: Sorted by quality/capability
    - **Lowest Cost**: Sorted by price efficiency
    - **Lowest Latency**: Sorted by SLO headroom
-   - **Simplest**: Sorted by deployment complexity (fewest GPUs)
    - **Balanced**: Sorted by weighted composite score (user priorities)
 
 2. Provide detailed rationale for each recommendation:
@@ -384,7 +377,7 @@ without real benchmark data
 - Model + GPU configuration details
 - Predicted performance metrics
 - Cost estimates (hourly, monthly)
-- Quality/complexity/latency scores
+- Quality/latency scores
 - Trade-off analysis vs. alternatives
 
 **Interface**: REST endpoint `/api/v1/ranked-recommend-from-spec`
@@ -504,8 +497,8 @@ components:
      ↓
 5. Recommendation Service
    a. Config Finder: Query benchmarks, calculate replicas
-   b. Scorer: Evaluate on 4 dimensions (accuracy, cost, latency, complexity)
-   c. Analyzer: Generate 5 ranked views
+   b. Scorer: Evaluate on 3 dimensions (accuracy, cost, latency)
+   c. Analyzer: Generate 4 ranked views
      ↓
 6. UI Recommendation Viewer
    - Display ranked options (Best Accuracy, Lowest Cost, etc.)
@@ -651,7 +644,7 @@ for different environments and requirements.
 2. **Specification Editability**: Users can review and modify auto-generated
    specs before committing
 3. **Multi-Criteria Optimization**: Balanced recommendations across accuracy,
-   cost, latency, and complexity
+   cost, and latency
 4. **SLO-Driven Planning**: Recommendations guaranteed to meet user's latency
    and throughput requirements
 5. **Explainability**: Clear rationale for why each recommendation was made,

--- a/docs/Planner Solution Ranking.md
+++ b/docs/Planner Solution Ranking.md
@@ -2,18 +2,18 @@
 
 ### Overview
 
-Planner recommends optimal LLM and GPU configurations that satisfy users' specific use cases and performance requirements. This document describes the implemented multi-criteria ranking system that scores and presents configuration options based on four optimization criteria.
+Planner recommends optimal LLM and GPU configurations that satisfy users' specific use cases and performance requirements. This document describes the implemented multi-criteria ranking system that scores and presents configuration options based on three optimization criteria.
 
-**Key Design Principle**: Configuration-first approach. The system queries all (model, GPU) configurations meeting SLO targets, then scores each on four criteria. This ensures no viable configurations are missed due to model pre-filtering.
+**Key Design Principle**: Configuration-first approach. The system queries all (model, GPU) configurations meeting SLO targets, then scores each on three criteria. This ensures no viable configurations are missed due to model pre-filtering.
 
 **Priority Hierarchy:**
-- **Primary Criteria**: Accuracy and Price (40% weight each in balanced score)
-- **Secondary Criteria**: Latency Performance and Operational Complexity (10% weight each)
+- **Primary Criteria**: Accuracy and Price (45% weight each in balanced score)
+- **Secondary Criteria**: Latency Performance (10% weight)
 - **Note**: All recommendations are pre-filtered to meet SLO requirements, so latency becomes a secondary differentiator for headroom beyond compliance
 
 ***
 
-### The Four Optimization Criteria
+### The Three Optimization Criteria
 
 #### 1. Accuracy (Model Quality)
 
@@ -64,28 +64,6 @@ Where `min_cost` and `max_cost` are computed across all viable configurations fo
 
 ***
 
-#### 4. Operational Complexity
-
-**Definition**: The difficulty of deploying and managing the configuration.
-
-**Scoring Method**: Based on total GPU count:
-
-| GPU Count | Score |
-|-----------|-------|
-| 1 | 100 |
-| 2 | 90 |
-| 3 | 82 |
-| 4 | 75 |
-| 5 | 70 |
-| 6 | 65 |
-| 7 | 62 |
-| 8 | 60 |
-| >8 | Linear decay (60 - 2*(n-8)), minimum 40 |
-
-**Rationale**: Fewer GPUs = simpler networking, easier troubleshooting, lower coordination overhead. A 2x H100 deployment may be preferred over 8x L4 even at higher cost due to reduced operational burden.
-
-***
-
 ### Configuration Variants
 
 #### Quantization Options
@@ -95,7 +73,6 @@ Quantization (FP16, FP8, INT8, INT4) creates distinct benchmark entries for each
 **Impact on Scores**:
 - **Price**: Reduced memory → fewer GPUs needed → lower cost
 - **Latency**: Faster inference from smaller compute requirements
-- **Complexity**: Smaller memory footprint enables single-GPU deployments
 - **Accuracy**: Generally preserved for FP8; slight reduction for INT4
 
 Quantized variants are identified by model ID suffixes (e.g., `-fp8-dynamic`, `-quantized.w4a16`).
@@ -104,22 +81,20 @@ Quantized variants are identified by model ID suffixes (e.g., `-fp8-dynamic`, `-
 
 ### Balanced Score Calculation
 
-The balanced score combines all four criteria with configurable weights:
+The balanced score combines all three criteria with configurable weights:
 
 ```python
 balanced_score = (
     accuracy_score * weight_accuracy +
     price_score * weight_price +
-    latency_score * weight_latency +
-    complexity_score * weight_complexity
+    latency_score * weight_latency
 )
 ```
 
 **Default Weights**:
-- Accuracy: 40%
-- Price: 40%
+- Accuracy: 45%
+- Price: 45%
 - Latency: 10%
-- Complexity: 10%
 
 **Custom Weights**: The API accepts a `weights` parameter (0-10 scale per criterion) that normalizes to percentages. This allows users to adjust priorities without changing code.
 
@@ -133,15 +108,14 @@ balanced_score = (
 - **Minimum Accuracy**: Optional threshold (e.g., ≥70) to exclude low-quality models
 - **Maximum Cost**: Optional ceiling (e.g., ≤$500/month) for budget constraints
 
-#### Five Ranked Views
+#### Four Ranked Views
 
 Each view presents up to 10 configurations sorted by the relevant criterion:
 
 1. **Best Accuracy**: Sorted by accuracy score (descending)
 2. **Lowest Cost**: Sorted by price score (descending)
 3. **Lowest Latency**: Sorted by latency score (descending)
-4. **Simplest**: Sorted by complexity score (descending)
-5. **Balanced**: Sorted by weighted composite score (descending)
+4. **Balanced**: Sorted by weighted composite score (descending)
 
 #### Near-SLO Configurations
 
@@ -158,10 +132,10 @@ Configurations within 20% of SLO targets are included with clear warnings:
 
 | Component | Location | Responsibility |
 |-----------|----------|----------------|
-| `Scorer` | `src/planner/recommendation/scorer.py` | Calculate 4 scores (0-100 scale) |
+| `Scorer` | `src/planner/recommendation/scorer.py` | Calculate 3 scores (0-100 scale) |
 | `UseCaseQualityScorer` | `src/planner/recommendation/quality/usecase_scorer.py` | Accuracy scoring based on use case fit |
 | `ConfigFinder.plan_all_capacities()` | `src/planner/recommendation/config_finder.py` | Query benchmarks, score all configs |
-| `Analyzer` | `src/planner/recommendation/analyzer.py` | Filter and sort into 5 ranked lists |
+| `Analyzer` | `src/planner/recommendation/analyzer.py` | Filter and sort into 4 ranked lists |
 | `RecommendationWorkflow` | `src/planner/orchestration/workflow.py` | Orchestrate end-to-end flow |
 
 #### Data Flow
@@ -177,14 +151,13 @@ plan_all_capacities()
     │   ├── Look up model in catalog
     │   ├── Calculate accuracy via score_model()
     │   ├── Calculate latency score and SLO status
-    │   ├── Calculate complexity score
     │   └── Build DeploymentRecommendation with scores
     └── Calculate price scores (after min/max known)
     ↓
 RankingService.generate_ranked_lists()
     ├── Apply filters (min_accuracy, max_cost)
     ├── Recalculate balanced scores if custom weights
-    └── Sort into 5 ranked views
+    └── Sort into 4 ranked views
     ↓
 RankedRecommendationsResponse
 ```
@@ -192,7 +165,7 @@ RankedRecommendationsResponse
 #### API Endpoints
 
 - **`POST /api/v1/recommend`**: Returns single best recommendation (balanced score)
-- **`POST /api/v1/ranked-recommend-from-spec`**: Returns all 5 ranked lists with filter support
+- **`POST /api/v1/ranked-recommend-from-spec`**: Returns all 4 ranked lists with filter support
 
 ***
 
@@ -201,18 +174,18 @@ RankedRecommendationsResponse
 ```
 🎯 Lowest Cost (Top 5):
 
-1. ✅ Llama-3.1-8B-FP8 on 1x L4     - $584/month  (Scores: A=60, P=100, L=92, C=100)
-2. ✅ Mistral-7B on 1x L4           - $584/month  (Scores: A=55, P=100, L=90, C=100)
-3. ✅ Qwen-2.5-7B-FP8 on 1x L4      - $584/month  (Scores: A=55, P=100, L=91, C=100)
-4. ⚠️ Llama-3.1-70B-FP8 on 2x A100  - $2,555/month (Scores: A=85, P=72, L=78, C=90) [TTFT +15% over SLO]
-5. ✅ Llama-3.1-70B on 2x H100      - $6,205/month (Scores: A=85, P=45, L=95, C=90)
+1. ✅ Llama-3.1-8B-FP8 on 1x L4     - $584/month  (Scores: A=60, P=100, L=92)
+2. ✅ Mistral-7B on 1x L4           - $584/month  (Scores: A=55, P=100, L=90)
+3. ✅ Qwen-2.5-7B-FP8 on 1x L4      - $584/month  (Scores: A=55, P=100, L=91)
+4. ⚠️ Llama-3.1-70B-FP8 on 2x A100  - $2,555/month (Scores: A=85, P=72, L=78) [TTFT +15% over SLO]
+5. ✅ Llama-3.1-70B on 2x H100      - $6,205/month (Scores: A=85, P=45, L=95)
 
 🏆 Best Accuracy (Top 5):
 
-1. ✅ Llama-3.1-70B on 2x H100      - $6,205/month (Scores: A=85, P=45, L=95, C=90)
-2. ⚠️ Llama-3.1-70B-FP8 on 2x A100  - $2,555/month (Scores: A=85, P=72, L=78, C=90) [Near-miss]
-3. ✅ Mixtral-8x7B on 4x A100       - $5,110/month (Scores: A=78, P=50, L=92, C=75)
-4. ✅ Llama-3.1-8B on 1x L4         - $584/month   (Scores: A=60, P=100, L=92, C=100)
+1. ✅ Llama-3.1-70B on 2x H100      - $6,205/month (Scores: A=85, P=45, L=95)
+2. ⚠️ Llama-3.1-70B-FP8 on 2x A100  - $2,555/month (Scores: A=85, P=72, L=78) [Near-miss]
+3. ✅ Mixtral-8x7B on 4x A100       - $5,110/month (Scores: A=78, P=50, L=92)
+4. ✅ Llama-3.1-8B on 1x L4         - $584/month   (Scores: A=60, P=100, L=92)
 ...
 ```
 

--- a/docs/Recommendation Flow.md
+++ b/docs/Recommendation Flow.md
@@ -4,7 +4,7 @@ This document describes the end-to-end recommendation flow implemented in the Pl
 
 ## Overview
 
-The recommendation flow follows a **configuration-first approach**: rather than pre-filtering models, the system queries all (model, GPU) configurations that meet SLO targets from the benchmark database, then scores each on four criteria.
+The recommendation flow follows a **configuration-first approach**: rather than pre-filtering models, the system queries all (model, GPU) configurations that meet SLO targets from the benchmark database, then scores each on three criteria.
 
 ```
 User Message
@@ -15,9 +15,9 @@ Traffic Profile + SLO Targets (from templates)
     ↓
 Query PostgreSQL for SLO-compliant configurations
     ↓
-Score each configuration (accuracy, price, latency, complexity)
+Score each configuration (accuracy, price, latency)
     ↓
-Generate 5 ranked lists
+Generate 4 ranked lists
     ↓
 Return best recommendation or all ranked lists
 ```
@@ -29,7 +29,7 @@ Return best recommendation or all ranked lists
 | Endpoint | Purpose | Returns |
 |----------|---------|---------|
 | `POST /api/v1/recommend` | Simple recommendation | Single best config with YAML |
-| `POST /api/v1/ranked-recommend-from-spec` | Multi-criteria ranking | 5 ranked lists (10 configs each) |
+| `POST /api/v1/ranked-recommend-from-spec` | Multi-criteria ranking | 4 ranked lists (10 configs each) |
 | `POST /api/v1/re-recommend` | Re-run with edited specs | Single best config |
 | `POST /api/v1/regenerate-and-recommend` | Regenerate profile from intent | Single best config |
 
@@ -124,7 +124,7 @@ The `BenchmarkRepository` queries PostgreSQL for all (model, GPU, tensor_paralle
 
 **File**: [src/planner/recommendation/config_finder.py](../src/planner/recommendation/config_finder.py)
 
-The `ConfigFinder.plan_all_capacities()` method processes each benchmark configuration and calculates four scores.
+The `ConfigFinder.plan_all_capacities()` method processes each benchmark configuration and calculates three scores.
 
 **Input**:
 - Traffic profile and SLO targets
@@ -138,7 +138,7 @@ The `ConfigFinder.plan_all_capacities()` method processes each benchmark configu
 1. **Calculate replicas** needed to handle expected QPS (with 20% headroom)
 2. **Build GPU config** (tensor_parallel from benchmark, replicas from QPS calculation)
 3. **Calculate cost** from GPU type and count
-4. **Score on 4 dimensions** (see below)
+4. **Score on 3 dimensions** (see below)
 5. **Create DeploymentRecommendation** with scores attached
 
 **Key Function**:
@@ -157,7 +157,7 @@ all_configs = capacity_planner.plan_all_capacities(
 ### Step 5: Multi-Criteria Scoring
 
 **Files**:
-- [src/planner/recommendation/scorer.py](../src/planner/recommendation/scorer.py) - Calculates 4 scores
+- [src/planner/recommendation/scorer.py](../src/planner/recommendation/scorer.py) - Calculates 3 scores
 - [src/planner/recommendation/quality/usecase_scorer.py](../src/planner/recommendation/quality/usecase_scorer.py) - Benchmark-based quality scoring
 
 #### 5.1 Accuracy Score (0-100)
@@ -209,33 +209,15 @@ latency_score, slo_status = scorer.score_latency(
 )
 ```
 
-#### 5.4 Complexity Score (0-100)
+#### 5.4 Balanced Score
 
-Based on total GPU count:
-
-| GPU Count | Score |
-|-----------|-------|
-| 1 | 100 |
-| 2 | 90 |
-| 4 | 75 |
-| 8 | 60 |
-| >8 | Linear decay (min 40) |
-
-**Key Function**:
-```python
-complexity_score = scorer.score_complexity(gpu_count)
-```
-
-#### 5.5 Balanced Score
-
-Weighted composite of all four scores:
+Weighted composite of all three scores:
 
 ```python
 balanced_score = (
-    accuracy_score * 0.40 +
-    price_score * 0.40 +
-    latency_score * 0.10 +
-    complexity_score * 0.10
+    accuracy_score * 0.45 +
+    price_score * 0.45 +
+    latency_score * 0.10
 )
 ```
 
@@ -247,23 +229,22 @@ Custom weights can be provided via API (0-10 scale, normalized to percentages).
 
 **File**: [src/planner/recommendation/analyzer.py](../src/planner/recommendation/analyzer.py)
 
-The `Analyzer` generates 5 ranked lists from scored configurations.
+The `Analyzer` generates 4 ranked lists from scored configurations.
 
 **Input**: List of scored DeploymentRecommendations, optional filters
 
-**Output**: Dict with 5 keys, each containing top 10 configurations
+**Output**: Dict with 4 keys, each containing top 10 configurations
 
 **Filters Applied**:
 - `min_accuracy`: Exclude configs with accuracy < threshold
 - `max_cost`: Exclude configs with monthly cost > ceiling
 
-**5 Ranked Views**:
+**4 Ranked Views**:
 | View | Sorted By |
 |------|-----------|
 | `best_accuracy` | Accuracy score (descending) |
 | `lowest_cost` | Price score (descending) |
 | `lowest_latency` | Latency score (descending) |
-| `simplest` | Complexity score (descending) |
 | `balanced` | Weighted composite score (descending) |
 
 **Key Function**:
@@ -273,7 +254,7 @@ ranked_lists = ranking_service.generate_ranked_lists(
     min_accuracy=70,
     max_cost=5000,
     top_n=10,
-    weights={"accuracy": 4, "price": 4, "latency": 1, "complexity": 1}
+    weights={"accuracy": 4.5, "price": 4.5, "latency": 1}
 )
 ```
 
@@ -291,7 +272,7 @@ The `RecommendationWorkflow` orchestrates all steps and returns the appropriate 
 - Auto-generates YAML files
 
 **For `/api/v1/ranked-recommend-from-spec`**:
-- Returns `RankedRecommendationsResponse` with all 5 ranked lists
+- Returns `RankedRecommendationsResponse` with all 4 ranked lists
 - Includes specification (intent, traffic_profile, slo_targets)
 - Reports total configs evaluated and configs after filters
 
@@ -318,9 +299,9 @@ The `RecommendationWorkflow` orchestrates all steps and returns the appropriate 
 | `TrafficProfileGenerator` | specification/traffic_profile.py | Generate traffic profile and SLO targets |
 | `BenchmarkRepository` | knowledge_base/benchmarks.py | Query PostgreSQL for benchmarks |
 | `ConfigFinder` | recommendation/config_finder.py | Find viable configs, calculate scores |
-| `Scorer` | recommendation/scorer.py | Calculate 4 scores |
+| `Scorer` | recommendation/scorer.py | Calculate 3 scores |
 | `UseCaseQualityScorer` | recommendation/quality/usecase_scorer.py | Benchmark-based quality scores |
-| `Analyzer` | recommendation/analyzer.py | Filter and sort into 5 ranked lists |
+| `Analyzer` | recommendation/analyzer.py | Filter and sort into 4 ranked lists |
 | `ModelCatalog` | knowledge_base/model_catalog.py | Model metadata and GPU pricing |
 
 ---
@@ -364,7 +345,6 @@ User Request
            │       ├──► ModelEvaluator.score_model() (accuracy)
            │       │         └──► UseCaseQualityScorer (Artificial Analysis data)
            │       ├──► SolutionScorer.score_latency()
-           │       ├──► SolutionScorer.score_complexity()
            │       └──► ModelCatalog.calculate_gpu_cost()
            │
            └──► SolutionScorer.score_price() (after min/max known)
@@ -378,7 +358,7 @@ User Request
            │
            ├──► Apply filters (min_accuracy, max_cost)
            ├──► Recalculate balanced scores (if custom weights)
-           └──► Sort into 5 ranked views
+           └──► Sort into 4 ranked views
            │
            ▼
 ┌─────────────────────┐
@@ -424,8 +404,7 @@ Granite 3.1 8B on 1x H100:
   Accuracy: 72  (from weighted_scores CSV)
   Price: 85     (relatively inexpensive)
   Latency: 95   (well under SLO)
-  Complexity: 100 (single GPU)
-  Balanced: 82.5
+  Balanced: 80.15
 ```
 
 ---

--- a/docs/refactor-recommendation-api.md
+++ b/docs/refactor-recommendation-api.md
@@ -13,7 +13,7 @@ Remove dead code from the recommendation API. The UI has two functions that call
 | `throughput_priority` | **REMOVE** | Not used; throughput is handled by explicit `expected_qps` |
 | `weights` | **KEEP** | Drives MCDM scoring in `capacity_planner.py` |
 
-The `weights` dict (accuracy, price, latency, complexity) controls all recommendation ranking. The other fields are remnants of an older design.
+The `weights` dict (accuracy, price, latency) controls all recommendation ranking. The other fields are remnants of an older design.
 
 ---
 
@@ -39,7 +39,6 @@ weights = {
     "accuracy": st.session_state.get("weight_accuracy", 5),
     "price": st.session_state.get("weight_cost", 4),
     "latency": st.session_state.get("weight_latency", 2),
-    "complexity": 0,
 }
 
 recommendation = fetch_ranked_recommendations(

--- a/src/planner/api/routes/recommendation.py
+++ b/src/planner/api/routes/recommendation.py
@@ -28,7 +28,6 @@ class BalancedWeights(BaseModel):
     accuracy: int = 4
     price: int = 4
     latency: int = 1
-    complexity: int = 1
 
 
 class RankedRecommendationFromSpecRequest(BaseModel):
@@ -171,18 +170,17 @@ def ranked_recommend_from_spec(
     have already been extracted and potentially edited by the user.
     Skips intent extraction and uses provided specs directly.
 
-    Returns 5 ranked views of deployment configurations:
+    Returns 4 ranked views of deployment configurations:
     - balanced: Weighted composite score
     - best_accuracy: Top configs by model capability
     - lowest_cost: Top configs by price efficiency
     - lowest_latency: Top configs by SLO headroom
-    - simplest: Top configs by deployment simplicity
 
     Args:
         request: Request with pre-built specification and optional filters
 
     Returns:
-        RankedRecommendationsResponse with 5 ranked lists
+        RankedRecommendationsResponse with 4 ranked lists
     """
     try:
         # Log complete request for debugging
@@ -207,7 +205,7 @@ def ranked_recommend_from_spec(
         if request.weights:
             logger.info(
                 f"  weights: accuracy={request.weights.accuracy}, price={request.weights.price}, "
-                f"latency={request.weights.latency}, complexity={request.weights.complexity}"
+                f"latency={request.weights.latency}"
             )
         else:
             logger.info("  weights: None (using defaults)")
@@ -242,7 +240,6 @@ def ranked_recommend_from_spec(
                 "accuracy": request.weights.accuracy,
                 "price": request.weights.price,
                 "latency": request.weights.latency,
-                "complexity": request.weights.complexity,
             }
 
         # Generate ranked recommendations from specs

--- a/src/planner/orchestration/workflow.py
+++ b/src/planner/orchestration/workflow.py
@@ -242,7 +242,7 @@ class RecommendationWorkflow:
 
         This is the enhanced workflow that returns multiple ranked views
         instead of a single best recommendation. Useful for exploring
-        trade-offs between accuracy, cost, latency, and complexity.
+        trade-offs between accuracy, cost, and latency.
 
         Args:
             user_message: User's deployment request
@@ -251,10 +251,10 @@ class RecommendationWorkflow:
             max_cost: Maximum monthly cost filter (USD)
             include_near_miss: Whether to include near-SLO configurations
             weights: Optional custom weights for balanced score (0-10 scale)
-                     Keys: accuracy, price, latency, complexity
+                     Keys: accuracy, price, latency
 
         Returns:
-            RankedRecommendationsResponse with 5 ranked lists
+            RankedRecommendationsResponse with 4 ranked lists
         """
         logger.info("Starting ranked recommendation workflow")
 
@@ -319,7 +319,6 @@ class RecommendationWorkflow:
             best_accuracy=ranked_lists["best_accuracy"],
             lowest_cost=ranked_lists["lowest_cost"],
             lowest_latency=ranked_lists["lowest_latency"],
-            simplest=ranked_lists["simplest"],
             balanced=ranked_lists["balanced"],
             total_configs_evaluated=len(all_configs),
             configs_after_filters=configs_after_filters,
@@ -347,10 +346,10 @@ class RecommendationWorkflow:
             max_cost: Maximum monthly cost filter (USD)
             include_near_miss: Whether to include near-SLO configurations
             weights: Optional custom weights for balanced score (0-10 scale)
-                     Keys: accuracy, price, latency, complexity
+                     Keys: accuracy, price, latency
 
         Returns:
-            RankedRecommendationsResponse with 5 ranked lists
+            RankedRecommendationsResponse with 4 ranked lists
         """
         from planner.shared.schemas import (
             DeploymentIntent,
@@ -458,7 +457,6 @@ class RecommendationWorkflow:
             best_accuracy=ranked_lists["best_accuracy"],
             lowest_cost=ranked_lists["lowest_cost"],
             lowest_latency=ranked_lists["lowest_latency"],
-            simplest=ranked_lists["simplest"],
             balanced=ranked_lists["balanced"],
             total_configs_evaluated=len(all_configs),
             configs_after_filters=configs_after_filters,

--- a/src/planner/recommendation/analyzer.py
+++ b/src/planner/recommendation/analyzer.py
@@ -1,6 +1,6 @@
 """Ranking service for multi-criteria recommendation sorting.
 
-Each card (Best Accuracy, Lowest Cost, Best Latency, Simplest, Balanced)
+Each card (Best Accuracy, Lowest Cost, Best Latency, Balanced)
 ranks ALL filtered configurations independently by its own criterion.
 """
 
@@ -25,7 +25,7 @@ class Analyzer:
         preferred_models: list[str] | None = None,
     ) -> dict[str, list[DeploymentRecommendation]]:
         """
-        Generate 5 ranked lists, each sorted independently by its criterion.
+        Generate 4 ranked lists, each sorted independently by its criterion.
 
         Args:
             configurations: List of scored DeploymentRecommendations
@@ -33,13 +33,12 @@ class Analyzer:
             max_cost: Maximum monthly cost filter (USD)
             top_n: Number of top configurations to return per list
             weights: Optional custom weights for balanced score (0-10 scale)
-                     Keys: accuracy, price, latency, complexity
+                     Keys: accuracy, price, latency
             use_case: Use case identifier (unused, kept for API compatibility)
             preferred_models: User-specified models that bypass min_accuracy filter
 
         Returns:
-            Dict with keys: best_accuracy, lowest_cost, lowest_latency,
-                           simplest, balanced
+            Dict with keys: best_accuracy, lowest_cost, lowest_latency, balanced
         """
         filtered = self._apply_filters(configurations, min_accuracy, max_cost, preferred_models)
 
@@ -49,7 +48,6 @@ class Analyzer:
                 "best_accuracy": [],
                 "lowest_cost": [],
                 "lowest_latency": [],
-                "simplest": [],
                 "balanced": [],
             }
 
@@ -62,9 +60,6 @@ class Analyzer:
 
         def get_latency(x):
             return x.scores.latency_score if x.scores else 0
-
-        def get_complexity(x):
-            return x.scores.complexity_score if x.scores else 0
 
         def get_balanced(x):
             return x.scores.balanced_score if x.scores else 0.0
@@ -106,14 +101,6 @@ class Analyzer:
                 sorted(
                     filtered,
                     key=lambda x: (get_latency(x), get_accuracy(x), get_cost_inverted(x)),
-                    reverse=True,
-                ),
-                top_n,
-            ),
-            "simplest": deduplicate_by_model(
-                sorted(
-                    filtered,
-                    key=lambda x: (get_complexity(x), get_accuracy(x), get_cost_inverted(x)),
                     reverse=True,
                 ),
                 top_n,

--- a/src/planner/recommendation/config_finder.py
+++ b/src/planner/recommendation/config_finder.py
@@ -154,7 +154,7 @@ class ConfigFinder:
         Plan GPU capacity and return ALL viable configurations meeting SLO.
 
         Queries benchmarks for all (model, GPU) configurations meeting SLO targets,
-        then scores each on accuracy, price, latency, and complexity.
+        then scores each on accuracy, price, and latency.
 
         Args:
             traffic_profile: Traffic characteristics (prompt_tokens, output_tokens)
@@ -163,7 +163,7 @@ class ConfigFinder:
             include_near_miss: Whether to include configs within tolerance of SLO
             near_miss_tolerance: How much over SLO to allow (0.2 = 20%)
             weights: Custom weights for balanced score (0-10 scale)
-                     Keys: accuracy, price, latency, complexity
+                     Keys: accuracy, price, latency
             cluster_gpu_types: Detected GPU types from cluster (None = detection
                 not attempted, [] = no GPUs detected, non-empty = hard filter
                 intersected with user preferences)
@@ -403,8 +403,6 @@ class ConfigFinder:
                 model_size = model.size_parameters if model else bench.model_hf_repo
                 accuracy_score = scorer.score_accuracy_by_size(model_size)
 
-            complexity_score = scorer.score_complexity(total_gpus)  # Use total GPUs for complexity
-
             # Determine model_id and model_name
             # Use catalog info if available, otherwise use benchmark model_hf_repo
             model_id = model.model_id if model else bench.model_hf_repo
@@ -462,7 +460,6 @@ class ConfigFinder:
                     accuracy_score=accuracy_score,
                     price_score=0,  # Placeholder
                     latency_score=latency_score,
-                    complexity_score=complexity_score,
                     balanced_score=0.0,  # Placeholder
                     slo_status=slo_status,
                 ),
@@ -498,7 +495,6 @@ class ConfigFinder:
                             accuracy_score=rec.scores.accuracy_score,
                             price_score=price_score,
                             latency_score=rec.scores.latency_score,
-                            complexity_score=rec.scores.complexity_score,
                             weights=normalized_weights,
                         ),
                         1,

--- a/src/planner/recommendation/quality/usecase_scorer.py
+++ b/src/planner/recommendation/quality/usecase_scorer.py
@@ -6,7 +6,7 @@ on task-specific benchmarks (MMLU-Pro, LiveCodeBench, IFBench, etc.).
 Integration with Planner:
 - Provides use-case specific quality scores (replaces legacy size-based heuristics)
 - Andre's latency/throughput benchmarks from PostgreSQL are KEPT as-is
-- The final recommendation combines: Our quality + Andre's latency/cost/complexity
+- The final recommendation combines: Our quality + Andre's latency/cost scoring
 """
 
 import csv

--- a/src/planner/recommendation/scorer.py
+++ b/src/planner/recommendation/scorer.py
@@ -1,14 +1,13 @@
 """Solution scoring for multi-criteria recommendation ranking.
 
-Scores deployment configurations on 4 criteria (0-100 scale):
+Scores deployment configurations on 3 criteria (0-100 scale):
 - Accuracy/Quality: Model capability (from Artificial Analysis benchmarks or param count fallback)
 - Price: Cost efficiency (inverse of cost, normalized)
 - Latency: SLO compliance with capped scoring (from Andre's PostgreSQL benchmarks)
-- Complexity: Deployment simplicity (fewer GPUs = simpler)
 
 INTEGRATION NOTE:
 - Quality scoring: Uses Yuval's weighted_scores CSVs (Artificial Analysis benchmarks)
-- Latency/Price/Complexity: Uses Andre's scoring logic and benchmark data
+- Latency/Price: Uses Andre's scoring logic and benchmark data
 - Latency scoring uses min/max ranges from usecase_slo_workload.json to cap scoring
   (no extra credit for latencies below the "min" threshold)
 """
@@ -31,7 +30,7 @@ except ImportError:
 
 
 class Scorer:
-    """Score deployment configurations on 4 criteria (0-100 scale)."""
+    """Score deployment configurations on 3 criteria (0-100 scale)."""
 
     # Accuracy tiers based on model parameter count (in billions)
     # Larger models generally have higher accuracy/capability
@@ -52,24 +51,11 @@ class Scorer:
         480: 98,
     }
 
-    # Complexity scores based on total GPU count
-    COMPLEXITY_SCORES = {
-        1: 100,
-        2: 90,
-        3: 82,
-        4: 75,
-        5: 70,
-        6: 65,
-        7: 62,
-        8: 60,
-    }
-
     # Default weights for balanced score
     DEFAULT_WEIGHTS = {
-        "accuracy": 0.40,
-        "price": 0.40,
+        "accuracy": 0.45,
+        "price": 0.45,
         "latency": 0.10,
-        "complexity": 0.10,
     }
 
     def __init__(self):
@@ -369,34 +355,11 @@ class Scorer:
         )
         return score, slo_status
 
-    def score_complexity(self, total_gpu_count: int) -> int:
-        """
-        Score complexity based on deployment topology.
-
-        Args:
-            total_gpu_count: Total GPUs required (tensor_parallel * replicas)
-
-        Returns:
-            Score 0-100 (100 = simplest, lower = more complex)
-        """
-        # Use predefined scores or calculate for larger counts
-        if total_gpu_count in self.COMPLEXITY_SCORES:
-            score = self.COMPLEXITY_SCORES[total_gpu_count]
-        elif total_gpu_count > 8:
-            # Linear decay for very large deployments
-            score = max(40, 60 - (total_gpu_count - 8) * 2)
-        else:
-            score = 60
-
-        logger.debug(f"Complexity score for {total_gpu_count} GPUs: {score}")
-        return score
-
     def score_balanced(
         self,
         accuracy_score: int,
         price_score: int,
         latency_score: int,
-        complexity_score: int,
         weights: dict | None = None,
     ) -> float:
         """
@@ -406,9 +369,8 @@ class Scorer:
             accuracy_score: Accuracy score (0-100)
             price_score: Price score (0-100)
             latency_score: Latency score (0-100)
-            complexity_score: Complexity score (0-100)
-            weights: Optional custom weights (default: 40% accuracy, 40% price,
-                     10% latency, 10% complexity)
+            weights: Optional custom weights (default: 45% accuracy, 45% price,
+                     10% latency)
 
         Returns:
             Weighted composite score (0-100)
@@ -416,15 +378,12 @@ class Scorer:
         w = weights or self.DEFAULT_WEIGHTS
 
         balanced = (
-            accuracy_score * w["accuracy"]
-            + price_score * w["price"]
-            + latency_score * w["latency"]
-            + complexity_score * w["complexity"]
+            accuracy_score * w["accuracy"] + price_score * w["price"] + latency_score * w["latency"]
         )
 
         logger.debug(
             f"Balanced score: {balanced:.1f} "
-            f"(A={accuracy_score}, P={price_score}, L={latency_score}, C={complexity_score})"
+            f"(A={accuracy_score}, P={price_score}, L={latency_score})"
         )
         return round(balanced, 1)
 

--- a/src/planner/shared/schemas/recommendation.py
+++ b/src/planner/shared/schemas/recommendation.py
@@ -23,7 +23,6 @@ class ConfigurationScores(BaseModel):
     accuracy_score: int = Field(..., description="Model accuracy/capability score (0-100)")
     price_score: int = Field(..., description="Cost efficiency score - inverse of cost (0-100)")
     latency_score: int = Field(..., description="SLO headroom score (0-100)")
-    complexity_score: int = Field(..., description="Deployment simplicity score (0-100)")
     balanced_score: float = Field(..., description="Weighted composite score (0-100)")
     slo_status: Literal["compliant", "near_miss", "exceeds"] = Field(
         ..., description="SLO compliance status"
@@ -105,7 +104,7 @@ class DeploymentRecommendation(BaseModel):
 class RankedRecommendationsResponse(BaseModel):
     """Response containing multiple ranked recommendation lists.
 
-    Provides 5 different views of the same configurations, each sorted
+    Provides 4 different views of the same configurations, each sorted
     by a different criterion to help users explore trade-offs.
     """
 
@@ -134,9 +133,6 @@ class RankedRecommendationsResponse(BaseModel):
     )
     lowest_latency: list[DeploymentRecommendation] = Field(
         default_factory=list, description="Top configs sorted by latency score"
-    )
-    simplest: list[DeploymentRecommendation] = Field(
-        default_factory=list, description="Top configs sorted by complexity score"
     )
     balanced: list[DeploymentRecommendation] = Field(
         default_factory=list, description="Top configs sorted by weighted composite score"

--- a/tests/unit/test_workflow_gpu_detection.py
+++ b/tests/unit/test_workflow_gpu_detection.py
@@ -80,7 +80,6 @@ class TestWorkflowGPUDetection:
             "best_accuracy": [],
             "lowest_cost": [],
             "lowest_latency": [],
-            "simplest": [],
             "balanced": [],
         }
         mock_analyzer.get_unique_configs_count.return_value = 0

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -327,7 +327,7 @@ def fetch_ranked_recommendations(
         ttft_target_ms: TTFT SLO target
         itl_target_ms: ITL SLO target
         e2e_target_ms: E2E SLO target
-        weights: Optional dict with accuracy, price, latency, complexity weights (0-10)
+        weights: Optional dict with accuracy, price, latency weights (0-10)
         include_near_miss: Whether to include near-SLO configurations
         percentile: Which percentile to use for SLO comparison (mean, p90, p95, p99)
         preferred_gpu_types: Optional list of GPU types to filter by (empty = any GPU)

--- a/ui/app.py
+++ b/ui/app.py
@@ -476,7 +476,6 @@ def render_results_tab(priority: str):
         "accuracy": st.session_state.get("weight_accuracy", 5),
         "price": st.session_state.get("weight_cost", 4),
         "latency": st.session_state.get("weight_latency", 2),
-        "complexity": 0,
     }
 
     preferred_gpu_types = final_extraction.get("preferred_gpu_types", [])

--- a/ui/components/dialogs.py
+++ b/ui/components/dialogs.py
@@ -35,9 +35,6 @@ def _render_winner_details(winner: dict, priority: str, extraction: dict):
         "quality_score": backend_scores.get("accuracy_score", ui_breakdown.get("quality_score", 0)),
         "latency_score": backend_scores.get("latency_score", ui_breakdown.get("latency_score", 0)),
         "cost_score": backend_scores.get("price_score", ui_breakdown.get("cost_score", 0)),
-        "capacity_score": backend_scores.get(
-            "complexity_score", ui_breakdown.get("capacity_score", 0)
-        ),
     }
 
     # === FINAL RECOMMENDATION BOX ===
@@ -171,17 +168,14 @@ def _render_winner_details(winner: dict, priority: str, extraction: dict):
         q_score = breakdown.get("quality_score", 0)
         l_score = breakdown.get("latency_score", 0)
         c_score = breakdown.get("cost_score", 0)
-        cap_score = breakdown.get("capacity_score", 0)
 
         q_contrib = q_score * weights["accuracy"]
         l_contrib = l_score * weights["latency"]
         c_contrib = c_score * weights["cost"]
-        cap_contrib = 0  # Complexity weight is 0 in UI
 
         render_score_bar("Accuracy", "", q_score, "score-bar-accuracy", q_contrib)
         render_score_bar("Latency", "", l_score, "score-bar-latency", l_contrib)
         render_score_bar("Cost", "", c_score, "score-bar-cost", c_contrib)
-        render_score_bar("Capacity", "", cap_score, "score-bar-capacity", cap_contrib)
 
     with col2:
         st.subheader("Why This Model?")

--- a/ui/components/recommendations.py
+++ b/ui/components/recommendations.py
@@ -20,7 +20,7 @@ def _render_filter_summary():
         return
 
     all_passed = []
-    for cat in ["balanced", "best_accuracy", "lowest_cost", "lowest_latency", "simplest"]:
+    for cat in ["balanced", "best_accuracy", "lowest_cost", "lowest_latency"]:
         all_passed.extend(ranked_response.get(cat, []))
     unique_models = len({r.get("model_name", "") for r in all_passed if r.get("model_name")})
 
@@ -276,8 +276,6 @@ def render_top5_table(recommendations: list, priority: str):
     st.session_state.top5_accuracy = top5_accuracy
     st.session_state.top5_latency = top5_latency
     st.session_state.top5_cost = top5_cost
-    st.session_state.top5_simplest = ranked_response.get("simplest", [])[:5]
-
     # Render 4 category cards in a 2x2 grid
     col1, col2 = st.columns(2)
     _render_category_card("Balanced", top5_balanced, "final", "balanced", col1)
@@ -499,7 +497,7 @@ def render_recommendation_result(result: dict, priority: str, extraction: dict):
             winner = balanced_recs[0]
             recommendations = balanced_recs
         else:
-            for cat in ["best_accuracy", "lowest_cost", "lowest_latency", "simplest"]:
+            for cat in ["best_accuracy", "lowest_cost", "lowest_latency"]:
                 if ranked_response.get(cat):
                     winner = ranked_response[cat][0]
                     recommendations = ranked_response[cat]
@@ -531,7 +529,7 @@ def render_recommendation_result(result: dict, priority: str, extraction: dict):
 
     # Get all recommendations for the cards
     all_recs: list[dict[str, Any]] = []
-    for cat in ["balanced", "best_accuracy", "lowest_cost", "lowest_latency", "simplest"]:
+    for cat in ["balanced", "best_accuracy", "lowest_cost", "lowest_latency"]:
         cat_recs = (
             st.session_state.ranked_response.get(cat, [])
             if st.session_state.ranked_response

--- a/ui/components/slo.py
+++ b/ui/components/slo.py
@@ -259,9 +259,7 @@ def _render_priorities():
 
     def get_weight_for_priority(dimension: str, priority_level: str) -> int:
         pw = priority_weights_map.get(dimension, {})
-        default_weights = defaults_config.get(
-            "weights", {"accuracy": 5, "cost": 4, "latency": 2, "complexity": 2}
-        )
+        default_weights = defaults_config.get("weights", {"accuracy": 5, "cost": 4, "latency": 2})
         weight = pw.get(priority_level, default_weights.get(dimension, 5))
         logger.info(
             f"get_weight_for_priority({dimension}, {priority_level}): pw={pw}, weight={weight}"

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -34,7 +34,6 @@ def get_scores(rec: dict) -> dict:
         "accuracy": backend_scores.get("accuracy_score", 0),
         "latency": backend_scores.get("latency_score", 0),
         "cost": backend_scores.get("price_score", 0),
-        "complexity": backend_scores.get("complexity_score", 0),
         "final": backend_scores.get("balanced_score", 0),
     }
 

--- a/ui/state.py
+++ b/ui/state.py
@@ -43,7 +43,6 @@ SESSION_DEFAULTS: dict[str, Any] = {
     "top5_accuracy": [],
     "top5_latency": [],
     "top5_cost": [],
-    "top5_simplest": [],
     # Category card navigation (index into top-5 lists)
     "cat_idx_balanced": 0,
     "cat_idx_accuracy": 0,


### PR DESCRIPTION
The complexity score was one of four scoring dimensions that rated deployment simplicity based on GPU count (fewer GPUs = higher score). It was disabled a while back by hardcoding its weight to zero in the UI and removing it from the GUI, rather than removing the code. We have since decided the complexity score is not needed, so this commit removes all traces of it from the codebase and documentation.

Changes:
- Remove COMPLEXITY_SCORES table, score_complexity() method, and complexity_score parameter from the scorer, config finder, and schema layers
- Remove the "simplest" ranked view (which sorted by complexity), reducing ranked views from 5 to 4
- Update DEFAULT_WEIGHTS from 4 dimensions (40/40/10/10) to 3 dimensions (45/45/10), preserving the same relative ratio
- Remove complexity from the BalancedWeights API model, workflow orchestration, and UI components (dialogs, helpers, state, recommendations, SLO weights)
- Clean up priority_weights.json and slo_ranges.json configuration
- Update all documentation: CLAUDE.md, README.md, ARCHITECTURE.md, Solution Ranking, Recommendation Flow, and related docs